### PR TITLE
TileDB integration with Tensorflow Sparse Data API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ tiledb>=0.8.5
 torch>=1.8.1
 scikit-learn>=0.23.0
 torchvision>=0.9.1
-tensorflow>=2.2.0,<=2.4.0
+tensorflow==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ tiledb>=0.8.5
 torch>=1.8.1
 scikit-learn>=0.23.0
 torchvision>=0.9.1
-tensorflow==2.4.0
+tensorflow>=2.2.0,<=2.4.0

--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -121,9 +121,9 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                     batch_size=BATCH_SIZE,
                 )
 
-                with tiledb.SparseArray(
-                    tiledb_uri_x, mode="r"
-                ) as x, tiledb.SparseArray(tiledb_uri_y, mode="r") as y:
+                with tiledb.open(tiledb_uri_x, mode="r") as x, tiledb.open(
+                    tiledb_uri_y, mode="r"
+                ) as y:
                     tiledb_dataset = TensorflowTileDBSparseDataset(
                         x_array=x, y_array=y, batch_size=BATCH_SIZE
                     )
@@ -157,7 +157,7 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                     batch_size=BATCH_SIZE,
                 )
 
-                with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
+                with tiledb.open(tiledb_uri_x, mode="r") as x, tiledb.open(
                     tiledb_uri_y, mode="r"
                 ) as y:
                     tiledb_dataset = TensorflowTileDBSparseDataset(
@@ -198,7 +198,7 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                     batch_size=BATCH_SIZE,
                 )
 
-                with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
+                with tiledb.open(tiledb_uri_x, mode="r") as x, tiledb.open(
                     tiledb_uri_y, mode="r"
                 ) as y:
                     tiledb_dataset = TensorflowTileDBSparseDataset(
@@ -228,7 +228,7 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
             batch_size=BATCH_SIZE,
         )
 
-        with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.SparseArray(
+        with tiledb.open(tiledb_uri_x, mode="r") as x, tiledb.open(
             tiledb_uri_y, mode="r"
         ) as y:
             with self.assertRaises(Exception):

--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -18,19 +18,22 @@ from tensorflow.python.keras import testing_utils
 from tensorflow.python.platform import test
 
 from tiledb.ml.data_apis.tensorflow_sparse import TensorflowTileDBSparseDataset
+# from tiledb.ml.utils import pprint_sparse_tensor
+
 
 # Suppress all Tensorflow messages
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 
 tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
+tf.compat.v1.enable_eager_execution()
 
 # Test parameters
-NUM_OF_CLASSES = 5
+NUM_OF_CLASSES = 1
 BATCH_SIZE = 32
 ROWS = 1000
 
 # We test for 2d, 3d, 4d and 5d data
-INPUT_SHAPES = [(10,)]
+INPUT_SHAPES = [(10,),]
 
 
 class CustomRandomState(np.random.RandomState):
@@ -38,6 +41,29 @@ class CustomRandomState(np.random.RandomState):
         i = np.random.randint(k)
         return i - i % 2
 
+def ingest_in_tiledb(data: np.array, batch_size: int, uri: str):
+    dims = [
+        tiledb.Dim(
+            name="dim_" + str(dim),
+            domain=(0, data.shape[dim] - 1),
+            tile=data.shape[dim] if dim > 0 else batch_size,
+            dtype=np.int32,
+        )
+        for dim in range(data.ndim)
+    ]
+
+    # TileDB schema
+    schema = tiledb.ArraySchema(
+        domain=tiledb.Domain(*dims),
+        sparse=False,
+        attrs=[tiledb.Attr(name="features", dtype=np.float32)],
+    )
+    # Create array
+    tiledb.Array.create(uri, schema)
+
+    # Ingest
+    with tiledb.open(uri, "w") as tiledb_array:
+        tiledb_array[:] = data
 
 def ingest_in_tiledb_sparse(data: np.array, batch_size: int, uri: str):
     dims = [
@@ -62,22 +88,45 @@ def ingest_in_tiledb_sparse(data: np.array, batch_size: int, uri: str):
 
     # Ingest
     with tiledb.open(uri, "w") as tiledb_array:
-        # print(data)
         I,J = data.row, data.col
         data_elem = np.array(data.data)
         tiledb_array[I, J] = data_elem
 
+# def pprint_sparse_tensor(st):
+#   x = "<SparseTensor shape=%s \n values={" % (st[0].dense_shape.numpy().tolist(),)
+#   for (index, value) in zip(st[0].indices, st[0].values):
+#     x += f"\n  %s: %s" % (index.numpy().tolist(), value.numpy().tolist()) + "}>"
+#   x = x + "}>"
+#   y = "<SparseTensor shape=%s \n values={" % (st[1].dense_shape.numpy().tolist(),)
+#   for (index, value) in zip(st[1].indices, st[1].values):
+#       y += f"\n  %s: %s" % (index.numpy().tolist(), value.numpy().tolist()) + "}>"
+#   y = y + "}>"
+#   return print(x + "|--------------------|" + y)
 
 def create_model(input_shape: tuple, num_of_classes: int):
+
     model = Sequential()
-    model.add(tf.keras.Input(shape=input_shape, sparse=True))
-    #model.add(Flatten())
-    model.add(Dense(64))
-    # model.add(Dropout(0.5))
+    model.add(tf.keras.Input(shape=input_shape))
     # model.add(Dense(num_of_classes))
+    # # model.add(Dropout(0.5))
+    # # model.add(Dense(num_of_classes))
+    #
+    # # model = Sequential()
+    # # model.add(tf.keras.Input(shape=input_shape, sparse=True))
+    # # # model.add(Dense(1))
     model.compile(
-        loss="categorical_crossentropy", optimizer="rmsprop", metrics=["binary_accuracy"],
+        # loss="sparse_categorical_crossentropy", optimizer="rmsprop", metrics=["sparse_binary_accuracy"],
     )
+
+    # x = tf.keras.Input(shape=input_shape, name='x')
+    # y_pred = tf.keras.layers.Dense(1, name='y_pred')(x)
+    # model = tf.keras.Model(inputs=x, outputs=y_pred)
+    # loss = tf.keras.losses.MeanSquaredError(reduction=tf.keras.losses.Reduction.NONE)
+    # model.compile('Adam', loss=loss)
+
+    # x = tf.keras.Input(shape=(10,), sparse=True)
+    # y = tf.keras.layers.Dense(10)(x)
+    # model = tf.keras.Model(x, y)
 
     return model
 
@@ -87,9 +136,9 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
     def test_sparse_tiledb_tf_data_api_with_multiple_dim_data(self):
         for input_shape in INPUT_SHAPES:
             with self.subTest():
-                # model = create_model(
-                #     input_shape=input_shape, num_of_classes=NUM_OF_CLASSES
-                # )
+                model = create_model(
+                    input_shape=input_shape, num_of_classes=NUM_OF_CLASSES
+                )
 
                 array_uuid = str(uuid.uuid4())
                 tiledb_uri_x = os.path.join(self.get_temp_dir(), "x" + array_uuid)
@@ -121,8 +170,11 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
 
                     self.assertIsInstance(tiledb_dataset, tf.data.Dataset)
 
-                    # model(tiledb_dataset[0])
-                    # model.predict(tiledb_dataset[0])
+                    # for item in tiledb_dataset:
+                    #     pprint_sparse_tensor(item)
+                    # model.fit(tiledb_dataset, epochs=2)
+
+                    model.fit(tiledb_dataset, verbose=0, epochs=1)
 
     @testing_utils.run_v2_only
     def test_sparse_except_with_diff_number_of_x_y_rows(self):
@@ -142,13 +194,13 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
             data=random(*dataset_shape_x, density=0.25, random_state=rs, data_rvs=rvs),
             batch_size=BATCH_SIZE,
         )
-        ingest_in_tiledb_sparse(
+        ingest_in_tiledb(
             uri=tiledb_uri_y,
-            data=random(*dataset_shape_y, density=0.25, random_state=rs, data_rvs=rvs),
+            data=np.random.rand(*dataset_shape_y),
             batch_size=BATCH_SIZE,
         )
 
-        with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.SparseArray(
+        with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
                 tiledb_uri_y, mode="r"
         ) as y:
             with self.assertRaises(Exception):

--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -31,9 +31,9 @@ INPUT_SHAPES = [
 ]
 
 
-def create_sparse_array_one_hot_2d(dims: tuple) -> np.ndarray:
-    seed = np.random.randint(low=0, high=dims[1][0], size=(dims[0],))
-    seed[-1] = dims[1][0] - 1
+def create_sparse_array_one_hot_2d(rows: int, cols: tuple) -> np.ndarray:
+    seed = np.random.randint(low=0, high=cols[0], size=(rows,))
+    seed[-1] = cols[0] - 1
     b = np.zeros((seed.size, seed.max() + 1))
     b[np.arange(seed.size), seed] = 1
     return b
@@ -81,7 +81,7 @@ def ingest_in_tiledb_sparse(data: np.array, batch_size: int, uri: str):
     with tiledb.open(uri, "w") as tiledb_array:
         idx = np.nonzero(data)
         I, J = idx[0], idx[1]
-        tiledb_array[I, J] = {"features": data[np.nonzero(data)]}
+        tiledb_array[I, J] = {"features": data[idx]}
 
 
 def create_model(input_shape: tuple, num_of_classes: int) -> object:
@@ -112,12 +112,16 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
 
                 ingest_in_tiledb_sparse(
                     uri=tiledb_uri_x,
-                    data=create_sparse_array_one_hot_2d(dataset_shape_x),
+                    data=create_sparse_array_one_hot_2d(
+                        dataset_shape_x[0], dataset_shape_x[1]
+                    ),
                     batch_size=BATCH_SIZE,
                 )
                 ingest_in_tiledb_sparse(
                     uri=tiledb_uri_y,
-                    data=create_sparse_array_one_hot_2d(dataset_shape_y),
+                    data=create_sparse_array_one_hot_2d(
+                        dataset_shape_y[0], dataset_shape_y[1]
+                    ),
                     batch_size=BATCH_SIZE,
                 )
 
@@ -146,7 +150,9 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
 
                 ingest_in_tiledb_sparse(
                     uri=tiledb_uri_x,
-                    data=create_sparse_array_one_hot_2d(dataset_shape_x),
+                    data=create_sparse_array_one_hot_2d(
+                        dataset_shape_x[0], dataset_shape_x[1]
+                    ),
                     batch_size=BATCH_SIZE,
                 )
                 ingest_in_tiledb(
@@ -180,7 +186,9 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                 dataset_shape_y = (ROWS, NUM_OF_CLASSES)
 
                 # Empty one random row
-                spoiled_data = create_sparse_array_one_hot_2d(dataset_shape_x)
+                spoiled_data = create_sparse_array_one_hot_2d(
+                    dataset_shape_x[0], dataset_shape_x[1]
+                )
                 spoiled_data[np.nonzero(spoiled_data[0])] = 0
 
                 ingest_in_tiledb_sparse(
@@ -213,12 +221,12 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
 
         ingest_in_tiledb_sparse(
             uri=tiledb_uri_x,
-            data=create_sparse_array_one_hot_2d(dataset_shape_x),
+            data=create_sparse_array_one_hot_2d(dataset_shape_x[0], dataset_shape_x[1]),
             batch_size=BATCH_SIZE,
         )
         ingest_in_tiledb_sparse(
             uri=tiledb_uri_y,
-            data=create_sparse_array_one_hot_2d(dataset_shape_y),
+            data=create_sparse_array_one_hot_2d(dataset_shape_y[0], dataset_shape_y[1]),
             batch_size=BATCH_SIZE,
         )
 

--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -41,18 +41,6 @@ def create_sparse_array_one_hot_2d(dims: tuple) -> np.ndarray:
     return b
 
 
-# def create_sparse_array_one_hot_nd(size: tuple, axis=-1, dtype=bool):
-#     a = x = np.random.randint(5, size=(3, 2))
-#     pos = axis if axis >= 0 else a.ndim + axis + 1
-#     shape = list(a.shape)
-#     shape.insert(pos, a.max() + 1)
-#     out = np.zeros(shape, dtype)
-#     ind = list(np.indices(a.shape, sparse=True))
-#     ind.insert(pos, a)
-#     out[tuple(ind)] = True
-#     return out
-
-
 def ingest_in_tiledb(data: np.array, batch_size: int, uri: str):
     dims = [
         tiledb.Dim(

--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -218,10 +218,10 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                 with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
                         tiledb_uri_y, mode="r"
                 ) as y:
-                    with self.assertRaises(Exception):
-                        TensorflowTileDBSparseDataset(
+                    _ = TensorflowTileDBSparseDataset(
                             x_array=x, y_array=y, batch_size=BATCH_SIZE
                         )
+                    self.assertRaises(Exception)
 
     @testing_utils.run_v2_only
     def test_sparse_except_with_diff_number_of_x_y_rows(self):

--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -6,7 +6,6 @@ import tiledb
 import numpy as np
 import uuid
 
-
 import tensorflow as tf
 from tensorflow.keras.models import Sequential
 
@@ -35,13 +34,12 @@ INPUT_SHAPES = [
 def create_sparse_array_one_hot_2d(dims: tuple) -> np.ndarray:
     seed = np.random.randint(low=0, high=dims[1][0], size=(dims[0],))
     seed[-1] = dims[1][0] - 1
-    a = np.array(seed)
-    b = np.zeros((a.size, a.max() + 1))
-    b[np.arange(a.size), a] = 1
+    b = np.zeros((seed.size, seed.max() + 1))
+    b[np.arange(seed.size), seed] = 1
     return b
 
 
-def ingest_in_tiledb(data: np.array, batch_size: int, uri: str):
+def get_schema(data: np.array, batch_size: int, sparse: bool) -> tiledb.ArraySchema:
     dims = [
         tiledb.Dim(
             name="dim_" + str(dim),
@@ -55,9 +53,16 @@ def ingest_in_tiledb(data: np.array, batch_size: int, uri: str):
     # TileDB schema
     schema = tiledb.ArraySchema(
         domain=tiledb.Domain(*dims),
-        sparse=False,
+        sparse=sparse,
         attrs=[tiledb.Attr(name="features", dtype=np.float32)],
     )
+
+    return schema
+
+
+def ingest_in_tiledb(data: np.array, batch_size: int, uri: str):
+    schema = get_schema(data, batch_size, False)
+
     # Create array
     tiledb.Array.create(uri, schema)
 
@@ -67,31 +72,16 @@ def ingest_in_tiledb(data: np.array, batch_size: int, uri: str):
 
 
 def ingest_in_tiledb_sparse(data: np.array, batch_size: int, uri: str):
-    dims = [
-        tiledb.Dim(
-            name="dim_" + str(dim),
-            domain=(0, data.shape[dim] - 1),
-            tile=data.shape[dim] if dim > 0 else batch_size,
-            dtype=np.int32,
-        )
-        for dim in range(data.ndim)
-    ]
-
-    # The array will be sparse with a single attribute "a" so each (i,j) cell can store an integer.
-    schema = tiledb.ArraySchema(
-        domain=tiledb.Domain(*dims),
-        sparse=True,
-        attrs=[tiledb.Attr(name="features", dtype=np.float32)],
-    )
+    schema = get_schema(data, batch_size, True)
 
     # Create the (empty) array on disk.
-    tiledb.SparseArray.create(uri, schema)
+    tiledb.Array.create(uri, schema)
 
     # Ingest
     with tiledb.open(uri, "w") as tiledb_array:
-        idx = data.nonzero()
+        idx = np.nonzero(data)
         I, J = idx[0], idx[1]
-        tiledb_array[I, J] = data[np.nonzero(data)]
+        tiledb_array[I, J] = {"features": data[np.nonzero(data)]}
 
 
 def create_model(input_shape: tuple, num_of_classes: int) -> object:
@@ -183,6 +173,9 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
     ):
         for input_shape in INPUT_SHAPES:
             with self.subTest():
+                model = create_model(
+                    input_shape=input_shape, num_of_classes=NUM_OF_CLASSES
+                )
                 array_uuid = str(uuid.uuid4())
                 tiledb_uri_x = os.path.join(self.get_temp_dir(), "x" + array_uuid)
                 tiledb_uri_y = os.path.join(self.get_temp_dir(), "y" + array_uuid)
@@ -208,10 +201,11 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                 with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
                     tiledb_uri_y, mode="r"
                 ) as y:
-                    _ = TensorflowTileDBSparseDataset(
+                    tiledb_dataset = TensorflowTileDBSparseDataset(
                         x_array=x, y_array=y, batch_size=BATCH_SIZE
                     )
-                    self.assertRaises(Exception)
+                    with self.assertRaises(Exception):
+                        model.fit(tiledb_dataset, verbose=0, epochs=2)
 
     @testing_utils.run_v2_only
     def test_sparse_except_with_diff_number_of_x_y_rows(self):

--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -2,12 +2,10 @@
 
 import os
 
-import numpy
 import tiledb
 import numpy as np
 import uuid
-from scipy.sparse import random
-from scipy import stats
+
 
 import tensorflow as tf
 from tensorflow.keras.models import Sequential
@@ -29,7 +27,9 @@ BATCH_SIZE = 32
 ROWS = 1000
 
 # We test for 2d
-INPUT_SHAPES = [(10,), ]
+INPUT_SHAPES = [
+    (10,),
+]
 
 
 def create_sparse_array_one_hot_2d(dims: tuple) -> np.ndarray:
@@ -131,9 +131,9 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                     batch_size=BATCH_SIZE,
                 )
 
-                with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.SparseArray(
-                        tiledb_uri_y, mode="r"
-                ) as y:
+                with tiledb.SparseArray(
+                    tiledb_uri_x, mode="r"
+                ) as x, tiledb.SparseArray(tiledb_uri_y, mode="r") as y:
                     tiledb_dataset = TensorflowTileDBSparseDataset(
                         x_array=x, y_array=y, batch_size=BATCH_SIZE
                     )
@@ -168,7 +168,7 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                 )
 
                 with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
-                        tiledb_uri_y, mode="r"
+                    tiledb_uri_y, mode="r"
                 ) as y:
                     tiledb_dataset = TensorflowTileDBSparseDataset(
                         x_array=x, y_array=y, batch_size=BATCH_SIZE
@@ -178,7 +178,9 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                     model.fit(tiledb_dataset, verbose=0, epochs=2)
 
     @testing_utils.run_v2_only
-    def test_tiledb_tf_sparse_data_api_with_sparse_data_diff_number_of_batch_x_y_rows(self):
+    def test_tiledb_tf_sparse_data_api_with_sparse_data_diff_number_of_batch_x_y_rows(
+        self,
+    ):
         for input_shape in INPUT_SHAPES:
             with self.subTest():
                 array_uuid = str(uuid.uuid4())
@@ -204,11 +206,11 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                 )
 
                 with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
-                        tiledb_uri_y, mode="r"
+                    tiledb_uri_y, mode="r"
                 ) as y:
                     _ = TensorflowTileDBSparseDataset(
-                            x_array=x, y_array=y, batch_size=BATCH_SIZE
-                        )
+                        x_array=x, y_array=y, batch_size=BATCH_SIZE
+                    )
                     self.assertRaises(Exception)
 
     @testing_utils.run_v2_only
@@ -233,7 +235,7 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
         )
 
         with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.SparseArray(
-                tiledb_uri_y, mode="r"
+            tiledb_uri_y, mode="r"
         ) as y:
             with self.assertRaises(Exception):
                 TensorflowTileDBSparseDataset(

--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -6,6 +6,7 @@ import numpy as np
 import uuid
 from scipy.sparse import random
 from scipy import stats
+import sparse
 
 import tensorflow as tf
 from tensorflow.keras.models import Sequential
@@ -18,7 +19,6 @@ from tensorflow.python.keras import testing_utils
 from tensorflow.python.platform import test
 
 from tiledb.ml.data_apis.tensorflow_sparse import TensorflowTileDBSparseDataset
-# from tiledb.ml.utils import pprint_sparse_tensor
 
 
 # Suppress all Tensorflow messages
@@ -88,45 +88,16 @@ def ingest_in_tiledb_sparse(data: np.array, batch_size: int, uri: str):
 
     # Ingest
     with tiledb.open(uri, "w") as tiledb_array:
-        I,J = data.row, data.col
+        I, J = data.row, data.col
         data_elem = np.array(data.data)
         tiledb_array[I, J] = data_elem
 
-# def pprint_sparse_tensor(st):
-#   x = "<SparseTensor shape=%s \n values={" % (st[0].dense_shape.numpy().tolist(),)
-#   for (index, value) in zip(st[0].indices, st[0].values):
-#     x += f"\n  %s: %s" % (index.numpy().tolist(), value.numpy().tolist()) + "}>"
-#   x = x + "}>"
-#   y = "<SparseTensor shape=%s \n values={" % (st[1].dense_shape.numpy().tolist(),)
-#   for (index, value) in zip(st[1].indices, st[1].values):
-#       y += f"\n  %s: %s" % (index.numpy().tolist(), value.numpy().tolist()) + "}>"
-#   y = y + "}>"
-#   return print(x + "|--------------------|" + y)
 
 def create_model(input_shape: tuple, num_of_classes: int):
 
     model = Sequential()
     model.add(tf.keras.Input(shape=input_shape))
-    # model.add(Dense(num_of_classes))
-    # # model.add(Dropout(0.5))
-    # # model.add(Dense(num_of_classes))
-    #
-    # # model = Sequential()
-    # # model.add(tf.keras.Input(shape=input_shape, sparse=True))
-    # # # model.add(Dense(1))
-    model.compile(
-        # loss="sparse_categorical_crossentropy", optimizer="rmsprop", metrics=["sparse_binary_accuracy"],
-    )
-
-    # x = tf.keras.Input(shape=input_shape, name='x')
-    # y_pred = tf.keras.layers.Dense(1, name='y_pred')(x)
-    # model = tf.keras.Model(inputs=x, outputs=y_pred)
-    # loss = tf.keras.losses.MeanSquaredError(reduction=tf.keras.losses.Reduction.NONE)
-    # model.compile('Adam', loss=loss)
-
-    # x = tf.keras.Input(shape=(10,), sparse=True)
-    # y = tf.keras.layers.Dense(10)(x)
-    # model = tf.keras.Model(x, y)
+    model.compile()
 
     return model
 

--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -141,9 +141,6 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
 
                     self.assertIsInstance(tiledb_dataset, tf.data.Dataset)
 
-                    # for item in tiledb_dataset:
-                    #     pprint_sparse_tensor(item)
-                    # model.fit(tiledb_dataset, epochs=2)
 
                     model.fit(tiledb_dataset, verbose=0, epochs=1)
 

--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -32,13 +32,14 @@ ROWS = 1000
 INPUT_SHAPES = [(10,), ]
 
 
-def create_sparse_array_one_hot_2d(dims: tuple):
+def create_sparse_array_one_hot_2d(dims: tuple) -> np.ndarray:
     seed = np.random.randint(low=0, high=dims[1][0], size=(dims[0],))
     seed[-1] = dims[1][0] - 1
     a = np.array(seed)
     b = np.zeros((a.size, a.max() + 1))
     b[np.arange(a.size), a] = 1
     return b
+
 
 # def create_sparse_array_one_hot_nd(size: tuple, axis=-1, dtype=bool):
 #     a = x = np.random.randint(5, size=(3, 2))
@@ -76,6 +77,7 @@ def ingest_in_tiledb(data: np.array, batch_size: int, uri: str):
     with tiledb.open(uri, "w") as tiledb_array:
         tiledb_array[:] = {"features": data}
 
+
 def ingest_in_tiledb_sparse(data: np.array, batch_size: int, uri: str):
     dims = [
         tiledb.Dim(
@@ -107,6 +109,8 @@ def ingest_in_tiledb_sparse(data: np.array, batch_size: int, uri: str):
 def create_model(input_shape: tuple, num_of_classes: int) -> object:
     model = Sequential()
     model.add(tf.keras.Input(shape=input_shape, sparse=True))
+    # TODO: TF https://github.com/tensorflow/tensorflow/issues/47532
+    # TODO: TF https://github.com/tensorflow/tensorflow/issues/47931
     model.compile()
 
     return model
@@ -147,7 +151,7 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                     )
 
                     self.assertIsInstance(tiledb_dataset, tf.data.Dataset)
-                    model.fit(tiledb_dataset, epochs=2)
+                    model.fit(tiledb_dataset, verbose=0, epochs=2)
 
     @testing_utils.run_v2_only
     def test_tiledb_tf_sparse_data_api_with_sparse_data_dense_label(self):
@@ -163,7 +167,6 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
 
                 dataset_shape_x = (ROWS, input_shape)
                 dataset_shape_y = (ROWS, NUM_OF_CLASSES)
-
 
                 ingest_in_tiledb_sparse(
                     uri=tiledb_uri_x,
@@ -184,13 +187,12 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                     )
 
                     self.assertIsInstance(tiledb_dataset, tf.data.Dataset)
-                    model.fit(tiledb_dataset, epochs=2)
+                    model.fit(tiledb_dataset, verbose=0, epochs=2)
 
     @testing_utils.run_v2_only
     def test_tiledb_tf_sparse_data_api_with_sparse_data_diff_number_of_batch_x_y_rows(self):
         for input_shape in INPUT_SHAPES:
             with self.subTest():
-
                 array_uuid = str(uuid.uuid4())
                 tiledb_uri_x = os.path.join(self.get_temp_dir(), "x" + array_uuid)
                 tiledb_uri_y = os.path.join(self.get_temp_dir(), "y" + array_uuid)
@@ -216,11 +218,10 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                 with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
                         tiledb_uri_y, mode="r"
                 ) as y:
-                    tiledb_dataset = TensorflowTileDBSparseDataset(
-                        x_array=x, y_array=y, batch_size=BATCH_SIZE
-                    )
-
-                    self.assertRaises(Exception)
+                    with self.assertRaises(Exception):
+                        TensorflowTileDBSparseDataset(
+                            x_array=x, y_array=y, batch_size=BATCH_SIZE
+                        )
 
     @testing_utils.run_v2_only
     def test_sparse_except_with_diff_number_of_x_y_rows(self):

--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -1,45 +1,56 @@
 """Tests for TileDB integration with Tensorflow Data API."""
 
 import os
+
+import numpy
 import tiledb
 import numpy as np
 import uuid
 from scipy.sparse import random
 from scipy import stats
-import sparse
 
 import tensorflow as tf
 from tensorflow.keras.models import Sequential
-from tensorflow.keras.layers import (
-    Dense,
-    Flatten,
-    Dropout,
-)
+
 from tensorflow.python.keras import testing_utils
 from tensorflow.python.platform import test
 
 from tiledb.ml.data_apis.tensorflow_sparse import TensorflowTileDBSparseDataset
 
-
 # Suppress all Tensorflow messages
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 
 tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
-tf.compat.v1.enable_eager_execution()
+# tf.compat.v1.enable_eager_execution()
 
 # Test parameters
 NUM_OF_CLASSES = 1
 BATCH_SIZE = 32
 ROWS = 1000
 
-# We test for 2d, 3d, 4d and 5d data
-INPUT_SHAPES = [(10,),]
+# We test for 2d
+INPUT_SHAPES = [(10,), ]
 
 
-class CustomRandomState(np.random.RandomState):
-    def randint(self, k):
-        i = np.random.randint(k)
-        return i - i % 2
+def create_sparse_array_one_hot_2d(dims: tuple):
+    seed = np.random.randint(low=0, high=dims[1][0], size=(dims[0],))
+    seed[-1] = dims[1][0] - 1
+    a = np.array(seed)
+    b = np.zeros((a.size, a.max() + 1))
+    b[np.arange(a.size), a] = 1
+    return b
+
+# def create_sparse_array_one_hot_nd(size: tuple, axis=-1, dtype=bool):
+#     a = x = np.random.randint(5, size=(3, 2))
+#     pos = axis if axis >= 0 else a.ndim + axis + 1
+#     shape = list(a.shape)
+#     shape.insert(pos, a.max() + 1)
+#     out = np.zeros(shape, dtype)
+#     ind = list(np.indices(a.shape, sparse=True))
+#     ind.insert(pos, a)
+#     out[tuple(ind)] = True
+#     return out
+
 
 def ingest_in_tiledb(data: np.array, batch_size: int, uri: str):
     dims = [
@@ -63,7 +74,7 @@ def ingest_in_tiledb(data: np.array, batch_size: int, uri: str):
 
     # Ingest
     with tiledb.open(uri, "w") as tiledb_array:
-        tiledb_array[:] = data
+        tiledb_array[:] = {"features": data}
 
 def ingest_in_tiledb_sparse(data: np.array, batch_size: int, uri: str):
     dims = [
@@ -88,15 +99,14 @@ def ingest_in_tiledb_sparse(data: np.array, batch_size: int, uri: str):
 
     # Ingest
     with tiledb.open(uri, "w") as tiledb_array:
-        I, J = data.row, data.col
-        data_elem = np.array(data.data)
-        tiledb_array[I, J] = data_elem
+        idx = data.nonzero()
+        I, J = idx[0], idx[1]
+        tiledb_array[I, J] = data[np.nonzero(data)]
 
 
-def create_model(input_shape: tuple, num_of_classes: int):
-
+def create_model(input_shape: tuple, num_of_classes: int) -> object:
     model = Sequential()
-    model.add(tf.keras.Input(shape=input_shape))
+    model.add(tf.keras.Input(shape=input_shape, sparse=True))
     model.compile()
 
     return model
@@ -104,7 +114,7 @@ def create_model(input_shape: tuple, num_of_classes: int):
 
 class TestTileDBTensorflowSparseDataAPI(test.TestCase):
     @testing_utils.run_v2_only
-    def test_sparse_tiledb_tf_data_api_with_multiple_dim_data(self):
+    def test_tiledb_tf_sparse_data_api_with_with_sparse_data_sparse_label(self):
         for input_shape in INPUT_SHAPES:
             with self.subTest():
                 model = create_model(
@@ -115,20 +125,17 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                 tiledb_uri_x = os.path.join(self.get_temp_dir(), "x" + array_uuid)
                 tiledb_uri_y = os.path.join(self.get_temp_dir(), "y" + array_uuid)
 
-                dataset_shape_x = (ROWS,) + input_shape
-                dataset_shape_y = (ROWS, NUM_OF_CLASSES)
-
-                rs = CustomRandomState()
-                rvs = stats.poisson(25, loc=10).rvs
+                dataset_shape_x = (ROWS, input_shape)
+                dataset_shape_y = (ROWS, (NUM_OF_CLASSES,))
 
                 ingest_in_tiledb_sparse(
                     uri=tiledb_uri_x,
-                    data=random(*dataset_shape_x, density=0.25, random_state=rs, data_rvs=rvs),
+                    data=create_sparse_array_one_hot_2d(dataset_shape_x),
                     batch_size=BATCH_SIZE,
                 )
                 ingest_in_tiledb_sparse(
                     uri=tiledb_uri_y,
-                    data=random(*dataset_shape_y, density=0.25, random_state=rs, data_rvs=rvs),
+                    data=create_sparse_array_one_hot_2d(dataset_shape_y),
                     batch_size=BATCH_SIZE,
                 )
 
@@ -140,9 +147,80 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                     )
 
                     self.assertIsInstance(tiledb_dataset, tf.data.Dataset)
+                    model.fit(tiledb_dataset, epochs=2)
+
+    @testing_utils.run_v2_only
+    def test_tiledb_tf_sparse_data_api_with_sparse_data_dense_label(self):
+        for input_shape in INPUT_SHAPES:
+            with self.subTest():
+                model = create_model(
+                    input_shape=input_shape, num_of_classes=NUM_OF_CLASSES
+                )
+
+                array_uuid = str(uuid.uuid4())
+                tiledb_uri_x = os.path.join(self.get_temp_dir(), "x" + array_uuid)
+                tiledb_uri_y = os.path.join(self.get_temp_dir(), "y" + array_uuid)
+
+                dataset_shape_x = (ROWS, input_shape)
+                dataset_shape_y = (ROWS, NUM_OF_CLASSES)
 
 
-                    model.fit(tiledb_dataset, verbose=0, epochs=1)
+                ingest_in_tiledb_sparse(
+                    uri=tiledb_uri_x,
+                    data=create_sparse_array_one_hot_2d(dataset_shape_x),
+                    batch_size=BATCH_SIZE,
+                )
+                ingest_in_tiledb(
+                    uri=tiledb_uri_y,
+                    data=np.random.rand(*dataset_shape_y),
+                    batch_size=BATCH_SIZE,
+                )
+
+                with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
+                        tiledb_uri_y, mode="r"
+                ) as y:
+                    tiledb_dataset = TensorflowTileDBSparseDataset(
+                        x_array=x, y_array=y, batch_size=BATCH_SIZE
+                    )
+
+                    self.assertIsInstance(tiledb_dataset, tf.data.Dataset)
+                    model.fit(tiledb_dataset, epochs=2)
+
+    @testing_utils.run_v2_only
+    def test_tiledb_tf_sparse_data_api_with_sparse_data_diff_number_of_batch_x_y_rows(self):
+        for input_shape in INPUT_SHAPES:
+            with self.subTest():
+
+                array_uuid = str(uuid.uuid4())
+                tiledb_uri_x = os.path.join(self.get_temp_dir(), "x" + array_uuid)
+                tiledb_uri_y = os.path.join(self.get_temp_dir(), "y" + array_uuid)
+
+                dataset_shape_x = (ROWS, input_shape)
+                dataset_shape_y = (ROWS, NUM_OF_CLASSES)
+
+                # Empty one random row
+                spoiled_data = create_sparse_array_one_hot_2d(dataset_shape_x)
+                spoiled_data[np.nonzero(spoiled_data[0])] = 0
+
+                ingest_in_tiledb_sparse(
+                    uri=tiledb_uri_x,
+                    data=spoiled_data,
+                    batch_size=BATCH_SIZE,
+                )
+                ingest_in_tiledb(
+                    uri=tiledb_uri_y,
+                    data=np.random.rand(*dataset_shape_y),
+                    batch_size=BATCH_SIZE,
+                )
+
+                with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
+                        tiledb_uri_y, mode="r"
+                ) as y:
+                    tiledb_dataset = TensorflowTileDBSparseDataset(
+                        x_array=x, y_array=y, batch_size=BATCH_SIZE
+                    )
+
+                    self.assertRaises(Exception)
 
     @testing_utils.run_v2_only
     def test_sparse_except_with_diff_number_of_x_y_rows(self):
@@ -151,24 +229,21 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
         tiledb_uri_y = os.path.join(self.get_temp_dir(), "y" + array_uuid)
 
         # Add one extra row on X
-        dataset_shape_x = (ROWS + 1,) + INPUT_SHAPES[0]
-        dataset_shape_y = (ROWS, NUM_OF_CLASSES)
-
-        rs = CustomRandomState()
-        rvs = stats.poisson(25, loc=10).rvs
+        dataset_shape_x = (ROWS + 1, INPUT_SHAPES[0])
+        dataset_shape_y = (ROWS, (NUM_OF_CLASSES,))
 
         ingest_in_tiledb_sparse(
             uri=tiledb_uri_x,
-            data=random(*dataset_shape_x, density=0.25, random_state=rs, data_rvs=rvs),
+            data=create_sparse_array_one_hot_2d(dataset_shape_x),
             batch_size=BATCH_SIZE,
         )
-        ingest_in_tiledb(
+        ingest_in_tiledb_sparse(
             uri=tiledb_uri_y,
-            data=np.random.rand(*dataset_shape_y),
+            data=create_sparse_array_one_hot_2d(dataset_shape_y),
             batch_size=BATCH_SIZE,
         )
 
-        with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
+        with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.SparseArray(
                 tiledb_uri_y, mode="r"
         ) as y:
             with self.assertRaises(Exception):

--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -1,0 +1,157 @@
+"""Tests for TileDB integration with Tensorflow Data API."""
+
+import os
+import tiledb
+import numpy as np
+import uuid
+from scipy.sparse import random
+from scipy import stats
+
+import tensorflow as tf
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import (
+    Dense,
+    Flatten,
+    Dropout,
+)
+from tensorflow.python.keras import testing_utils
+from tensorflow.python.platform import test
+
+from tiledb.ml.data_apis.tensorflow_sparse import TensorflowTileDBSparseDataset
+
+# Suppress all Tensorflow messages
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+
+tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
+
+# Test parameters
+NUM_OF_CLASSES = 5
+BATCH_SIZE = 32
+ROWS = 1000
+
+# We test for 2d, 3d, 4d and 5d data
+INPUT_SHAPES = [(10,)]
+
+
+class CustomRandomState(np.random.RandomState):
+    def randint(self, k):
+        i = np.random.randint(k)
+        return i - i % 2
+
+
+def ingest_in_tiledb_sparse(data: np.array, batch_size: int, uri: str):
+    dims = [
+        tiledb.Dim(
+            name="dim_" + str(dim),
+            domain=(0, data.shape[dim] - 1),
+            tile=data.shape[dim] if dim > 0 else batch_size,
+            dtype=np.int32,
+        )
+        for dim in range(data.ndim)
+    ]
+
+    # The array will be sparse with a single attribute "a" so each (i,j) cell can store an integer.
+    schema = tiledb.ArraySchema(
+        domain=tiledb.Domain(*dims),
+        sparse=True,
+        attrs=[tiledb.Attr(name="features", dtype=np.float32)],
+    )
+
+    # Create the (empty) array on disk.
+    tiledb.SparseArray.create(uri, schema)
+
+    # Ingest
+    with tiledb.open(uri, "w") as tiledb_array:
+        # print(data)
+        I,J = data.row, data.col
+        data_elem = np.array(data.data)
+        tiledb_array[I, J] = data_elem
+
+
+def create_model(input_shape: tuple, num_of_classes: int):
+    model = Sequential()
+    model.add(tf.keras.Input(shape=input_shape, sparse=True))
+    #model.add(Flatten())
+    model.add(Dense(64))
+    # model.add(Dropout(0.5))
+    # model.add(Dense(num_of_classes))
+    model.compile(
+        loss="categorical_crossentropy", optimizer="rmsprop", metrics=["binary_accuracy"],
+    )
+
+    return model
+
+
+class TestTileDBTensorflowSparseDataAPI(test.TestCase):
+    @testing_utils.run_v2_only
+    def test_sparse_tiledb_tf_data_api_with_multiple_dim_data(self):
+        for input_shape in INPUT_SHAPES:
+            with self.subTest():
+                # model = create_model(
+                #     input_shape=input_shape, num_of_classes=NUM_OF_CLASSES
+                # )
+
+                array_uuid = str(uuid.uuid4())
+                tiledb_uri_x = os.path.join(self.get_temp_dir(), "x" + array_uuid)
+                tiledb_uri_y = os.path.join(self.get_temp_dir(), "y" + array_uuid)
+
+                dataset_shape_x = (ROWS,) + input_shape
+                dataset_shape_y = (ROWS, NUM_OF_CLASSES)
+
+                rs = CustomRandomState()
+                rvs = stats.poisson(25, loc=10).rvs
+
+                ingest_in_tiledb_sparse(
+                    uri=tiledb_uri_x,
+                    data=random(*dataset_shape_x, density=0.25, random_state=rs, data_rvs=rvs),
+                    batch_size=BATCH_SIZE,
+                )
+                ingest_in_tiledb_sparse(
+                    uri=tiledb_uri_y,
+                    data=random(*dataset_shape_y, density=0.25, random_state=rs, data_rvs=rvs),
+                    batch_size=BATCH_SIZE,
+                )
+
+                with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.SparseArray(
+                        tiledb_uri_y, mode="r"
+                ) as y:
+                    tiledb_dataset = TensorflowTileDBSparseDataset(
+                        x_array=x, y_array=y, batch_size=BATCH_SIZE
+                    )
+
+                    self.assertIsInstance(tiledb_dataset, tf.data.Dataset)
+
+                    # model(tiledb_dataset[0])
+                    # model.predict(tiledb_dataset[0])
+
+    @testing_utils.run_v2_only
+    def test_sparse_except_with_diff_number_of_x_y_rows(self):
+        array_uuid = str(uuid.uuid4())
+        tiledb_uri_x = os.path.join(self.get_temp_dir(), "x" + array_uuid)
+        tiledb_uri_y = os.path.join(self.get_temp_dir(), "y" + array_uuid)
+
+        # Add one extra row on X
+        dataset_shape_x = (ROWS + 1,) + INPUT_SHAPES[0]
+        dataset_shape_y = (ROWS, NUM_OF_CLASSES)
+
+        rs = CustomRandomState()
+        rvs = stats.poisson(25, loc=10).rvs
+
+        ingest_in_tiledb_sparse(
+            uri=tiledb_uri_x,
+            data=random(*dataset_shape_x, density=0.25, random_state=rs, data_rvs=rvs),
+            batch_size=BATCH_SIZE,
+        )
+        ingest_in_tiledb_sparse(
+            uri=tiledb_uri_y,
+            data=random(*dataset_shape_y, density=0.25, random_state=rs, data_rvs=rvs),
+            batch_size=BATCH_SIZE,
+        )
+
+        with tiledb.SparseArray(tiledb_uri_x, mode="r") as x, tiledb.SparseArray(
+                tiledb_uri_y, mode="r"
+        ) as y:
+            with self.assertRaises(Exception):
+                TensorflowTileDBSparseDataset(
+                    x_array=x, y_array=y, batch_size=BATCH_SIZE
+                )

--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -121,9 +121,7 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                     batch_size=BATCH_SIZE,
                 )
 
-                with tiledb.open(tiledb_uri_x, mode="r") as x, tiledb.open(
-                    tiledb_uri_y, mode="r"
-                ) as y:
+                with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
                     tiledb_dataset = TensorflowTileDBSparseDataset(
                         x_array=x, y_array=y, batch_size=BATCH_SIZE
                     )
@@ -157,9 +155,7 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                     batch_size=BATCH_SIZE,
                 )
 
-                with tiledb.open(tiledb_uri_x, mode="r") as x, tiledb.open(
-                    tiledb_uri_y, mode="r"
-                ) as y:
+                with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
                     tiledb_dataset = TensorflowTileDBSparseDataset(
                         x_array=x, y_array=y, batch_size=BATCH_SIZE
                     )
@@ -198,9 +194,7 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                     batch_size=BATCH_SIZE,
                 )
 
-                with tiledb.open(tiledb_uri_x, mode="r") as x, tiledb.open(
-                    tiledb_uri_y, mode="r"
-                ) as y:
+                with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
                     tiledb_dataset = TensorflowTileDBSparseDataset(
                         x_array=x, y_array=y, batch_size=BATCH_SIZE
                     )
@@ -228,9 +222,7 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
             batch_size=BATCH_SIZE,
         )
 
-        with tiledb.open(tiledb_uri_x, mode="r") as x, tiledb.open(
-            tiledb_uri_y, mode="r"
-        ) as y:
+        with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
             with self.assertRaises(Exception):
                 TensorflowTileDBSparseDataset(
                     x_array=x, y_array=y, batch_size=BATCH_SIZE

--- a/tiledb/ml/data_apis/tensorflow_sparse.py
+++ b/tiledb/ml/data_apis/tensorflow_sparse.py
@@ -81,6 +81,8 @@ class TensorflowTileDBSparseDataset(tf.data.Dataset):
     ) -> tuple:
         """
         A generator function that yields the next training batch.
+        :param x: TileDB Sparse array. An opened TileDB array which contains features.
+        :param y: TileDB Sparse array. An opened TileDB array which contains labels.
         :param rows: Integer. The number of observations in x, y datasets.
         :param batch_size: Integer. Size of batch, i.e., number of rows returned per call.
         :return: Tuple. Tuple that contains x and y batches.
@@ -89,6 +91,7 @@ class TensorflowTileDBSparseDataset(tf.data.Dataset):
         x_shape = x.schema.domain.shape[1:]
         y_shape = y.schema.domain.shape[1:]
 
+        x_dtype = x.schema.attr(0).dtype
         y_dtype = y.schema.attr(0).dtype
 
         # Loop over batches
@@ -123,7 +126,7 @@ class TensorflowTileDBSparseDataset(tf.data.Dataset):
 
             yield tf.sparse.SparseTensor(
                 indices=constant_op.constant(list(zip(*x_coords)), dtype=tf.int64),
-                values=constant_op.constant(x_data, dtype=tf.float32),
+                values=constant_op.constant(x_data, dtype=x_dtype),
                 dense_shape=(batch_size, x_shape[0]),
             ), tf.sparse.SparseTensor(
                 indices=constant_op.constant(list(zip(*y_coords)), dtype=tf.int64),
@@ -137,11 +140,14 @@ class TensorflowTileDBSparseDataset(tf.data.Dataset):
     ) -> tuple:
         """
         A generator function that yields the next training batch.
+        :param x: TileDB Sparse array. An opened TileDB array which contains features.
+        :param y: TileDB Dense array. An opened TileDB array which contains labels.
         :param rows: Integer. The number of observations in x, y datasets.
         :param batch_size: Integer. Size of batch, i.e., number of rows returned per call.
         :return: Tuple. Tuple that contains x and y batches.
         """
         x_shape = x.schema.domain.shape[1:]
+        x_dtype = x.schema.attr(0).dtype
 
         # Loop over batches
         # https://github.com/tensorflow/tensorflow/issues/44565
@@ -170,6 +176,6 @@ class TensorflowTileDBSparseDataset(tf.data.Dataset):
 
             yield tf.sparse.SparseTensor(
                 indices=constant_op.constant(list(zip(*x_coords)), dtype=tf.int64),
-                values=constant_op.constant(x_data, dtype=tf.float32),
+                values=constant_op.constant(x_data, dtype=x_dtype),
                 dense_shape=(batch_size, x_shape[0]),
             ), values_y

--- a/tiledb/ml/data_apis/tensorflow_sparse.py
+++ b/tiledb/ml/data_apis/tensorflow_sparse.py
@@ -28,7 +28,7 @@ class TensorflowTileDBSparseDataset(tf.data.Dataset):
 
         # Check that x and y have the same number of rows
         if x_array.schema.domain.shape[0] != y_array.schema.domain.shape[0]:
-            raise Exception(
+            raise ValueError(
                 "X and Y should have the same number of rows, i.e., the 1st dimension "
                 "of TileDB arrays X, Y should be of equal domain extent."
             )

--- a/tiledb/ml/data_apis/tensorflow_sparse.py
+++ b/tiledb/ml/data_apis/tensorflow_sparse.py
@@ -7,8 +7,6 @@ import numpy as np
 from tensorflow.python.framework import constant_op
 from tensorflow.python.data.ops import dataset_ops
 
-tf.compat.v1.disable_eager_execution()
-
 
 class TensorflowTileDBSparseDataset(tf.data.Dataset):
     """
@@ -20,7 +18,7 @@ class TensorflowTileDBSparseDataset(tf.data.Dataset):
         """
         Returns a Tensorflow Dataset object which loads data from TileDB arrays by employing a generator.
         :param x_array: TileDB Sparse Array. Array that contains features.
-        :param y_array: TileDB Sparse Array. Array that contains labels.
+        :param y_array: TileDB Dense/Sparse Array. Array that contains labels.
         :param batch_size: Integer. The size of the batch that the implemented _generator method will return.
         For optimal reads from a TileDB array, it is recommended to set the batch size equal to the tile extent of the
         dimension we query (here, we always query the first dimension of a TileDB array) in order to get a slice (batch)
@@ -51,17 +49,27 @@ class TensorflowTileDBSparseDataset(tf.data.Dataset):
         cls.x_dtype = x_array.schema.attr(0).dtype
         cls.y_dtype = y_array.schema.attr(0).dtype
 
-        return dataset_ops.Dataset.from_generator(
-            generator=cls._generator,
-            output_signature=(
-                tf.SparseTensorSpec(shape=cls.x_shape, dtype=cls.x_dtype),
-                tf.SparseTensorSpec(shape=cls.y_shape, dtype=cls.y_dtype)
-            ),
-            args=(rows, batch_size)
-        )
+        if isinstance(y_array, tiledb.SparseArray):
+            return dataset_ops.Dataset.from_generator(
+                generator=cls._generator_sparse_sparse,
+                output_signature=(
+                    tf.SparseTensorSpec(shape=cls.x_shape, dtype=cls.x_dtype),
+                    tf.SparseTensorSpec(shape=cls.y_shape, dtype=cls.y_dtype)
+                ),
+                args=(rows, batch_size)
+            )
+        else:
+            return dataset_ops.Dataset.from_generator(
+                generator=cls._generator_sparse_dense,
+                output_signature=(
+                    tf.SparseTensorSpec(shape=cls.x_shape, dtype=cls.x_dtype),
+                    tf.TensorSpec(shape=cls.y_shape, dtype=cls.y_dtype)
+                ),
+                args=(rows, batch_size)
+            )
 
     @classmethod
-    def _generator(cls, rows: int, batch_size: int) -> tuple:
+    def _generator_sparse_sparse(cls, rows: int, batch_size: int) -> tuple:
         """
         A generator function that yields the next training batch.
         :param x: TileDB array. An opened TileDB array which contains features.
@@ -73,21 +81,29 @@ class TensorflowTileDBSparseDataset(tf.data.Dataset):
         # Loop over batches
         # https://github.com/tensorflow/tensorflow/issues/44565
         for offset in range(0, rows, batch_size):
-            values_y = list(cls.y[offset: offset + batch_size].items())[0][1]
-            values_x = list(cls.x[offset: offset + batch_size].items())[0][1]
+            y_batch = cls.y[offset: offset + batch_size]
+            x_batch = cls.x[offset: offset + batch_size]
+            values_y = list(y_batch.items())[0][1]
+            values_x = list(x_batch.items())[0][1]
 
             y_data = np.array(values_y).flatten()
             y_coords = []
             for i in range(0, cls.y.schema.domain.ndim):
                 dim_name = cls.y.schema.domain.dim(i).name
-                y_coords.append(np.array(cls.y[offset: offset + batch_size][dim_name]))
+                y_coords.append(np.array(y_batch[dim_name]))
 
             x_coords = []
             for i in range(0, cls.x.schema.domain.ndim):
                 dim_name = cls.x.schema.domain.dim(i).name
-                x_coords.append(np.array(cls.x[offset: offset + batch_size][dim_name]))
+                x_coords.append(np.array(x_batch[dim_name]))
 
             x_data = np.array(values_x).flatten()
+
+            if x_data.shape[0] != y_data.shape[0]:
+                raise Exception(
+                    "X and Y should have the same number of rows, i.e., the 1st dimension "
+                    "of TileDB arrays X, Y should be of equal domain extent inside the batch"
+                )
 
             yield tf.sparse.SparseTensor(indices=constant_op.constant(list(zip(*x_coords)), dtype=tf.int64),
                                          values=constant_op.constant(x_data, dtype=tf.float32),
@@ -95,3 +111,42 @@ class TensorflowTileDBSparseDataset(tf.data.Dataset):
                   tf.sparse.SparseTensor(indices=constant_op.constant(list(zip(*y_coords)), dtype=tf.int64),
                                          values=constant_op.constant(y_data, dtype=cls.y_dtype),
                                          dense_shape=(batch_size, cls.y_shape[1]))
+
+    @classmethod
+    def _generator_sparse_dense(cls, rows: int, batch_size: int) -> tuple:
+        """
+        A generator function that yields the next training batch.
+        :param x: TileDB array. An opened TileDB array which contains features.
+        :param y: TileDB array. An opened TileDB array which contains labels.
+        :param rows: Integer. The number of observations in x, y datasets.
+        :param batch_size: Integer. Size of batch, i.e., number of rows returned per call.
+        :return: Tuple. Tuple that contains x and y batches.
+        """
+        # Loop over batches
+        # https://github.com/tensorflow/tensorflow/issues/44565
+        for offset in range(0, rows, batch_size):
+            y_batch = cls.y[offset: offset + batch_size]
+            x_batch = cls.x[offset: offset + batch_size]
+
+            #TODO: Both for dense case support multiple attributes
+            values_y = list(y_batch.items())[0][1]
+            values_x = list(x_batch.items())[0][1]
+
+            x_coords = []
+            for i in range(0, cls.x.schema.domain.ndim):
+                dim_name = cls.x.schema.domain.dim(i).name
+                x_coords.append(np.array(x_batch[dim_name]))
+
+            x_data = np.array(values_x).flatten()
+
+            x_sparse_real_batch_size = x_coords[0].max(axis=0) - x_coords[0].min(axis=0)
+            if values_y.shape[0] - x_sparse_real_batch_size != 1:
+                raise Exception(
+                    "X and Y should have the same number of rows, i.e., the 1st dimension "
+                    "of TileDB arrays X, Y should be of equal domain extent inside the batch"
+                )
+
+            yield tf.sparse.SparseTensor(indices=constant_op.constant(list(zip(*x_coords)), dtype=tf.int64),
+                                         values=constant_op.constant(x_data, dtype=tf.float32),
+                                         dense_shape=(batch_size, cls.x_shape[1])), \
+                  values_y

--- a/tiledb/ml/data_apis/tensorflow_sparse.py
+++ b/tiledb/ml/data_apis/tensorflow_sparse.py
@@ -1,0 +1,121 @@
+"""Functionality for loading data directly from TileDB arrays into the Tensorflow Data API."""
+import dataclasses
+
+import tiledb
+import tensorflow as tf
+import numpy as np
+from scipy.sparse import coo_matrix
+
+tf.compat.v1.disable_eager_execution()
+
+def pprint_sparse_tensor(st):
+  s = "<SparseTensor shape=%s \n values={" % (st.dense_shape.numpy().tolist(),)
+  for (index, value) in zip(st.indices, st.values):
+    s += f"\n  %s: %s" % (index.numpy().tolist(), value.numpy().tolist())
+  return s + "}>"
+
+class TensorflowTileDBSparseDataset(tf.data.Dataset):
+    """
+    Class that implements all functionality needed to load data from TileDB directly to the
+    Tensorflow Data API, by employing generators.
+    """
+
+    def __new__(cls, x_array: tiledb.Array, y_array: tiledb.Array, batch_size: int):
+        """
+        Returns a Tensorflow Dataset object which loads data from TileDB arrays by employing a generator.
+        :param x_array: TileDB Sparse Array. Array that contains features.
+        :param y_array: TileDB Sparse Array. Array that contains labels.
+        :param batch_size: Integer. The size of the batch that the implemented _generator method will return.
+        For optimal reads from a TileDB array, it is recommended to set the batch size equal to the tile extent of the
+        dimension we query (here, we always query the first dimension of a TileDB array) in order to get a slice (batch)
+        of the data. For example, in case the tile extent of the first dimension of a TileDB array (x or y) is equal to
+        32, it's recommended to set batch_size=32. Any batch size will work, but in case it's not equal the tile extent
+        of the first dimension of the TileDB array, you won't achieve highest read speed. For more details on tiles,
+        tile extent and indices in TileDB, please check here:
+        https://docs.tiledb.com/main/solutions/tiledb-embedded/performance-tips/choosing-tiling-and-cell-layout#dense-arrays
+        """
+
+        # Check that x and y have the same number of rows
+        if x_array.schema.domain.shape[0] != y_array.schema.domain.shape[0]:
+            raise Exception(
+                "X and Y should have the same number of rows, i.e., the 1st dimension "
+                "of TileDB arrays X, Y should be of equal domain extent."
+            )
+
+        # Get number of observations
+        rows = x_array.schema.domain.shape[0]
+
+        # Get x and y shapes
+        x_shape = (1000,) + x_array.schema.domain.shape[1:]
+        y_shape = (1000,) + y_array.schema.domain.shape[1:]
+
+        # Get x and y data types
+        x_dtype = x_array.schema.attr(0).dtype
+        y_dtype = y_array.schema.attr(0).dtype
+        #
+        # row = np.array([0, 3, 1, 0])
+        # col = np.array([0, 3, 1, 2])
+        # data = np.array([4, 5, 7, 9])
+        # a = coo_matrix((data, (row, col)), shape=(4, 4))
+        return tf.data.Dataset.from_generator(
+            generator=cls._generator,
+            output_signature=(
+                tf.TensorSpec(shape=x_shape, dtype=x_dtype),
+                tf.TensorSpec(shape=y_shape, dtype=y_dtype),
+            ),
+            args=(x_array, y_array, rows, batch_size),
+        )
+
+        # Loop over batches
+        # st_x = []
+        # st_y = []
+        # for offset in range(0, rows, batch_size):
+        #     values_x = x_array[offset: offset + batch_size]["features"],
+        #     indices_x = np.array(
+        #         list(zip(x_array[offset: offset + batch_size]["dim_0"], x_array[offset: offset + batch_size]["dim_1"])))
+        #     values_y = y_array[offset: offset + batch_size]["features"],
+        #     indices_y = np.array(
+        #         list(zip(y_array[offset: offset + batch_size]["dim_0"], y_array[offset: offset + batch_size]["dim_1"])))
+        #     st_x.append(tf.SparseTensor(indices=indices_x, values=values_x[0], dense_shape=x_shape))
+        #     st_y.append(tf.SparseTensor(indices=indices_y, values=values_y[0], dense_shape=y_shape))
+        #
+        # st_concat_x = tf.sparse.concat(axis=0, sp_inputs=st_x)
+        # st_concat_y = tf.sparse.concat(axis=0, sp_inputs=st_y)
+
+        # print(pprint_sparse_tensor(st_concat))
+        # print(type(st_concat))
+        # return (st_concat_x, st_concat_y)
+        # return tf.data.Dataset.from_generator(
+        #     generator=cls._generator,
+        #     output_types=tf.float32,
+        #     output_shapes=x_shape,
+        #     args=(x_array, y_array, rows, batch_size, x_shape, y_shape)
+        # )
+
+    @staticmethod
+    def _generator(
+            x: tiledb.Array, y: tiledb.Array, rows: int, batch_size: int
+    ) -> tuple:
+        """
+        A generator function that yields the next training batch.
+        :param x: TileDB array. An opened TileDB array which contains features.
+        :param y: TileDB array. An opened TileDB array which contains labels.
+        :param rows: Integer. The number of observations in x, y datasets.
+        :param batch_size: Integer. Size of batch, i.e., number of rows returned per call.
+        :return: Tuple. Tuple that contains x and y batches.
+        """
+        # Loop over batches
+        #https://github.com/tensorflow/tensorflow/issues/44565
+        for offset in range(0, rows, batch_size):
+        #     # Yield the next training batch
+        #     values_x = x[offset: offset + batch_size]["features"],
+        #     indices_x = np.array(
+        #         list(zip(x[offset: offset + batch_size]["dim_0"], x[offset: offset + batch_size]["dim_1"])))
+            # values_y = y[offset: offset + batch_size]["features"],
+            # indices_y = np.array(
+            #     list(zip(y[offset: offset + batch_size]["dim_0"], y[offset: offset + batch_size]["dim_1"])))
+        # values_a = x.data
+        # indices_a = np.array(list(zip(x.row, x.col)))
+            yield tf.SparseTensor(indices=indices_a, values=values_a, dense_shape=[4, 4])
+            # yield tf.SparseTensor(indices=indices_y, values=values_y[0], dense_shape=y_dshape)
+            # yield (indices_x, values_x[0]), (indices_y, values_y[0])

--- a/tiledb/ml/data_apis/tensorflow_sparse.py
+++ b/tiledb/ml/data_apis/tensorflow_sparse.py
@@ -4,15 +4,11 @@ import dataclasses
 import tiledb
 import tensorflow as tf
 import numpy as np
-from scipy.sparse import coo_matrix
+from tensorflow.python.framework import constant_op
+from tensorflow.python.data.ops import dataset_ops
 
 tf.compat.v1.disable_eager_execution()
 
-def pprint_sparse_tensor(st):
-  s = "<SparseTensor shape=%s \n values={" % (st.dense_shape.numpy().tolist(),)
-  for (index, value) in zip(st.indices, st.values):
-    s += f"\n  %s: %s" % (index.numpy().tolist(), value.numpy().tolist())
-  return s + "}>"
 
 class TensorflowTileDBSparseDataset(tf.data.Dataset):
     """
@@ -34,6 +30,8 @@ class TensorflowTileDBSparseDataset(tf.data.Dataset):
         tile extent and indices in TileDB, please check here:
         https://docs.tiledb.com/main/solutions/tiledb-embedded/performance-tips/choosing-tiling-and-cell-layout#dense-arrays
         """
+        cls.x = x_array
+        cls.y = y_array
 
         # Check that x and y have the same number of rows
         if x_array.schema.domain.shape[0] != y_array.schema.domain.shape[0]:
@@ -46,56 +44,24 @@ class TensorflowTileDBSparseDataset(tf.data.Dataset):
         rows = x_array.schema.domain.shape[0]
 
         # Get x and y shapes
-        x_shape = (1000,) + x_array.schema.domain.shape[1:]
-        y_shape = (1000,) + y_array.schema.domain.shape[1:]
+        cls.x_shape = (None,) + x_array.schema.domain.shape[1:]
+        cls.y_shape = (None,) + y_array.schema.domain.shape[1:]
 
         # Get x and y data types
-        x_dtype = x_array.schema.attr(0).dtype
-        y_dtype = y_array.schema.attr(0).dtype
-        #
-        # row = np.array([0, 3, 1, 0])
-        # col = np.array([0, 3, 1, 2])
-        # data = np.array([4, 5, 7, 9])
-        # a = coo_matrix((data, (row, col)), shape=(4, 4))
-        return tf.data.Dataset.from_generator(
+        cls.x_dtype = x_array.schema.attr(0).dtype
+        cls.y_dtype = y_array.schema.attr(0).dtype
+
+        return dataset_ops.Dataset.from_generator(
             generator=cls._generator,
             output_signature=(
-                tf.TensorSpec(shape=x_shape, dtype=x_dtype),
-                tf.TensorSpec(shape=y_shape, dtype=y_dtype),
+                tf.SparseTensorSpec(shape=cls.x_shape, dtype=tf.float32),
+                tf.SparseTensorSpec(shape=cls.y_shape, dtype=cls.y_dtype)
             ),
-            args=(x_array, y_array, rows, batch_size),
+            args=(rows, batch_size)
         )
 
-        # Loop over batches
-        # st_x = []
-        # st_y = []
-        # for offset in range(0, rows, batch_size):
-        #     values_x = x_array[offset: offset + batch_size]["features"],
-        #     indices_x = np.array(
-        #         list(zip(x_array[offset: offset + batch_size]["dim_0"], x_array[offset: offset + batch_size]["dim_1"])))
-        #     values_y = y_array[offset: offset + batch_size]["features"],
-        #     indices_y = np.array(
-        #         list(zip(y_array[offset: offset + batch_size]["dim_0"], y_array[offset: offset + batch_size]["dim_1"])))
-        #     st_x.append(tf.SparseTensor(indices=indices_x, values=values_x[0], dense_shape=x_shape))
-        #     st_y.append(tf.SparseTensor(indices=indices_y, values=values_y[0], dense_shape=y_shape))
-        #
-        # st_concat_x = tf.sparse.concat(axis=0, sp_inputs=st_x)
-        # st_concat_y = tf.sparse.concat(axis=0, sp_inputs=st_y)
-
-        # print(pprint_sparse_tensor(st_concat))
-        # print(type(st_concat))
-        # return (st_concat_x, st_concat_y)
-        # return tf.data.Dataset.from_generator(
-        #     generator=cls._generator,
-        #     output_types=tf.float32,
-        #     output_shapes=x_shape,
-        #     args=(x_array, y_array, rows, batch_size, x_shape, y_shape)
-        # )
-
-    @staticmethod
-    def _generator(
-            x: tiledb.Array, y: tiledb.Array, rows: int, batch_size: int
-    ) -> tuple:
+    @classmethod
+    def _generator(cls, rows: int, batch_size: int) -> tuple:
         """
         A generator function that yields the next training batch.
         :param x: TileDB array. An opened TileDB array which contains features.
@@ -105,17 +71,22 @@ class TensorflowTileDBSparseDataset(tf.data.Dataset):
         :return: Tuple. Tuple that contains x and y batches.
         """
         # Loop over batches
-        #https://github.com/tensorflow/tensorflow/issues/44565
+        # https://github.com/tensorflow/tensorflow/issues/44565
         for offset in range(0, rows, batch_size):
-        #     # Yield the next training batch
-        #     values_x = x[offset: offset + batch_size]["features"],
-        #     indices_x = np.array(
-        #         list(zip(x[offset: offset + batch_size]["dim_0"], x[offset: offset + batch_size]["dim_1"])))
-            # values_y = y[offset: offset + batch_size]["features"],
-            # indices_y = np.array(
-            #     list(zip(y[offset: offset + batch_size]["dim_0"], y[offset: offset + batch_size]["dim_1"])))
-        # values_a = x.data
-        # indices_a = np.array(list(zip(x.row, x.col)))
-            yield tf.SparseTensor(indices=indices_a, values=values_a, dense_shape=[4, 4])
-            # yield tf.SparseTensor(indices=indices_y, values=values_y[0], dense_shape=y_dshape)
-            # yield (indices_x, values_x[0]), (indices_y, values_y[0])
+            val_y = list(cls.y[offset: offset + batch_size].items())
+            values_y = val_y[0][1]
+            val_x = list(cls.x[offset: offset + batch_size].items())
+            values_x = val_x[0][1]
+            y_data = np.array(values_y).flatten()
+            y_rows = np.array(cls.y[offset: offset + batch_size]["dim_0"])
+            y_cols = np.array(cls.y[offset: offset + batch_size]["dim_1"])
+            x_data = np.array(values_x).flatten()
+            x_rows = np.array(cls.x[offset: offset + batch_size]["dim_0"])
+            x_cols = np.array(cls.x[offset: offset + batch_size]["dim_1"])
+
+            yield tf.sparse.SparseTensor(indices=constant_op.constant(list(zip(x_rows, x_cols)), dtype=tf.int64),
+                                         values=constant_op.constant(x_data, dtype=tf.float32),
+                                         dense_shape=(batch_size, cls.x_shape[1])), \
+                  tf.sparse.SparseTensor(indices=constant_op.constant(list(zip(y_rows, y_cols)), dtype=tf.int64),
+                                         values=constant_op.constant(y_data, dtype=cls.y_dtype),
+                                         dense_shape=(batch_size, cls.y_shape[1]))


### PR DESCRIPTION
This PR is about the integration of `TileDB` with `Tensorflow Sparse Data API`. With the implemented functionality, users are able to load data directly from `TileDB sparse arrays` into `Tensorflow` Data API (with the use of generators), in order to perform model trainings for supervised machine learning problems using Sparse Tensors. Code added is as follows:

```
TileDB-ML/tiledb/ml/data_apis/tensorflow_sparse.py
TileDB-ML/tests/test_tensorflow_sparse_data_api.py
```

Description:

The Class that implements all the needed functionality to read data directly from `TileDB sparse arrays` into `Tensorflow Data API`, with the use of `tensorflow.data.Dataset.from_generator`. Specifically, the user can initialise the implemented Class by passing `x` (tiledb array with features of any dimensionality) and `y` (tiledb array with labels of any dimensionality), and employ it in order to train a model with `Tensorflow Keras`. The Class allows users to use either `Dense` or `Sparse` representation for the `y` data (tiledb array with labels of any dimensionality). Sparse representation is mostly common in one-hot encoded labels. There are though open `Tensorflow` issues concerning the training of models with sparse labels (`TODOs`). Sparse representation in the datasets requires that the data elements both `x` and `y` have same dimension on the number of data observations. Commonly sparse slicing returns the nonempty records during the generation of the dataset, thus each sample record should at least have a non-empty value. Otherwise an `Exception` is being raised and the user gets informations.

Unit tests for the aforementioned Class.