### PR TITLE
Feature PyTorch Dataloader Support for Dense TileDB Arrays

### DIFF
--- a/tests/test_pytorch_dataloader_api.py
+++ b/tests/test_pytorch_dataloader_api.py
@@ -90,9 +90,9 @@ class TestTileDBDensePyTorchDataloaderAPI(unittest.TestCase):
                             batch_size=BATCH_SIZE,
                         )
 
-                        with tiledb.DenseArray(
-                            tiledb_uri_x, mode="r"
-                        ) as x, tiledb.DenseArray(tiledb_uri_y, mode="r") as y:
+                        with tiledb.open(tiledb_uri_x) as x, tiledb.open(
+                            tiledb_uri_y
+                        ) as y:
 
                             tiledb_dataset = PyTorchTileDBDenseDataset(
                                 x_array=x, y_array=y, batch_size=BATCH_SIZE
@@ -144,9 +144,7 @@ class TestTileDBDensePyTorchDataloaderAPI(unittest.TestCase):
                 batch_size=BATCH_SIZE,
             )
 
-            with tiledb.DenseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
-                tiledb_uri_y, mode="r"
-            ) as y:
+            with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
                 with self.assertRaises(Exception):
                     PyTorchTileDBDenseDataset(
                         x_array=x, y_array=y, batch_size=BATCH_SIZE
@@ -173,9 +171,7 @@ class TestTileDBDensePyTorchDataloaderAPI(unittest.TestCase):
                         batch_size=BATCH_SIZE,
                     )
 
-                    with tiledb.DenseArray(
-                        tiledb_uri_x, mode="r"
-                    ) as x, tiledb.DenseArray(tiledb_uri_y, mode="r") as y:
+                    with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
 
                         tiledb_dataset = PyTorchTileDBDenseDataset(
                             x_array=x, y_array=y, batch_size=BATCH_SIZE
@@ -207,6 +203,5 @@ class TestTileDBDensePyTorchDataloaderAPI(unittest.TestCase):
                             ):
                                 unique_labels.append(data[1].numpy())
 
-                        self.assertEqual(len(unique_labels), len(unique_inputs))
                         self.assertEqual(len(unique_inputs) - 1, batchindx)
                         self.assertEqual(len(unique_labels) - 1, batchindx)

--- a/tests/test_pytorch_dataloader_api.py
+++ b/tests/test_pytorch_dataloader_api.py
@@ -13,11 +13,14 @@ from tiledb.ml.data_apis.pytorch import PyTorchTileDBDenseDataset
 
 # Test parameters
 NUM_OF_CLASSES = 5
-BATCH_SIZE = 32
+BATCH_SIZE = 20
 ROWS = 1000
 
 # We test for 2d, 3d, 4d and 5d data
 INPUT_SHAPES = [(10,), (10, 3), (10, 10, 3), (10, 10, 10, 3)]
+
+# We test for single and multiple workers
+NUM_OF_WORKERS = [1, 2, 3, 4, 5]
 
 
 def ingest_in_tiledb(data: np.array, batch_size: int, uri: str):
@@ -67,10 +70,94 @@ class Net(nn.Module):
 class TestTileDBDensePyTorchDataloaderAPI(unittest.TestCase):
     def test_tiledb_pytorch_data_api_train_with_multiple_dim_data(self):
         for input_shape in INPUT_SHAPES:
+            for workers in NUM_OF_WORKERS:
+                with self.subTest():
+                    with tempfile.TemporaryDirectory() as tiledb_uri_x, tempfile.TemporaryDirectory() as tiledb_uri_y:
+
+                        dataset_shape_x = (ROWS,) + input_shape
+                        dataset_shape_y = (ROWS,)
+
+                        ingest_in_tiledb(
+                            uri=tiledb_uri_x,
+                            data=np.random.rand(*dataset_shape_x),
+                            batch_size=BATCH_SIZE,
+                        )
+                        ingest_in_tiledb(
+                            uri=tiledb_uri_y,
+                            data=np.random.randint(
+                                low=0, high=NUM_OF_CLASSES, size=dataset_shape_y
+                            ),
+                            batch_size=BATCH_SIZE,
+                        )
+
+                        with tiledb.DenseArray(
+                            tiledb_uri_x, mode="r"
+                        ) as x, tiledb.DenseArray(tiledb_uri_y, mode="r") as y:
+
+                            tiledb_dataset = PyTorchTileDBDenseDataset(
+                                x_array=x, y_array=y, batch_size=BATCH_SIZE
+                            )
+
+                            self.assertIsInstance(
+                                tiledb_dataset, torch.utils.data.IterableDataset
+                            )
+
+                            train_loader = torch.utils.data.DataLoader(
+                                tiledb_dataset, batch_size=None, num_workers=workers
+                            )
+
+                            # Train network
+                            net = Net(shape=dataset_shape_x[1:])
+                            criterion = nn.CrossEntropyLoss()
+                            optimizer = optim.SGD(
+                                net.parameters(), lr=0.001, momentum=0.9
+                            )
+
+                            for epoch in range(
+                                1
+                            ):  # loop over the dataset multiple times
+                                for inputs, labels in train_loader:
+                                    # zero the parameter gradients
+                                    optimizer.zero_grad()
+                                    # forward + backward + optimize
+                                    outputs = net(inputs)
+                                    loss = criterion(
+                                        outputs, labels.type(torch.LongTensor)
+                                    )
+                                    loss.backward()
+                                    optimizer.step()
+
+    def test_except_with_diff_number_of_x_y_rows(self):
+        with tempfile.TemporaryDirectory() as tiledb_uri_x, tempfile.TemporaryDirectory() as tiledb_uri_y:
+            # Add one extra row on X
+            dataset_shape_x = (ROWS + 1,) + INPUT_SHAPES[0]
+            dataset_shape_y = (ROWS, NUM_OF_CLASSES)
+
+            ingest_in_tiledb(
+                uri=tiledb_uri_x,
+                data=np.random.rand(*dataset_shape_x),
+                batch_size=BATCH_SIZE,
+            )
+            ingest_in_tiledb(
+                uri=tiledb_uri_y,
+                data=np.random.rand(*dataset_shape_y),
+                batch_size=BATCH_SIZE,
+            )
+
+            with tiledb.DenseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
+                tiledb_uri_y, mode="r"
+            ) as y:
+                with self.assertRaises(Exception):
+                    PyTorchTileDBDenseDataset(
+                        x_array=x, y_array=y, batch_size=BATCH_SIZE
+                    )
+
+    def test_no_duplicates_with_multiple_workers(self):
+        for workers in NUM_OF_WORKERS[2:]:
             with self.subTest():
                 with tempfile.TemporaryDirectory() as tiledb_uri_x, tempfile.TemporaryDirectory() as tiledb_uri_y:
 
-                    dataset_shape_x = (ROWS,) + input_shape
+                    dataset_shape_x = (ROWS,) + INPUT_SHAPES[1]
                     dataset_shape_y = (ROWS,)
 
                     ingest_in_tiledb(
@@ -99,45 +186,27 @@ class TestTileDBDensePyTorchDataloaderAPI(unittest.TestCase):
                         )
 
                         train_loader = torch.utils.data.DataLoader(
-                            tiledb_dataset, batch_size=None, num_workers=5
+                            tiledb_dataset, batch_size=None, num_workers=workers
                         )
 
-                        # Train network
-                        net = Net(shape=dataset_shape_x[1:])
-                        criterion = nn.CrossEntropyLoss()
-                        optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
+                        unique_inputs = []
+                        unique_labels = []
 
-                        for epoch in range(1):  # loop over the dataset multiple times
-                            for inputs, labels in train_loader:
-                                # zero the parameter gradients
-                                optimizer.zero_grad()
-                                # forward + backward + optimize
-                                outputs = net(inputs)
-                                loss = criterion(outputs, labels.type(torch.LongTensor))
-                                loss.backward()
-                                optimizer.step()
+                        for batchindx, data in enumerate(train_loader):
+                            # Keep unique X tensors
+                            if not any(
+                                np.array_equal(data[0].numpy(), unique_input)
+                                for unique_input in unique_inputs
+                            ):
+                                unique_inputs.append(data[0].numpy())
 
-    def test_except_with_diff_number_of_x_y_rows(self):
-        with tempfile.TemporaryDirectory() as tiledb_uri_x, tempfile.TemporaryDirectory() as tiledb_uri_y:
-            # Add one extra row on X
-            dataset_shape_x = (ROWS + 1,) + INPUT_SHAPES[0]
-            dataset_shape_y = (ROWS, NUM_OF_CLASSES)
+                            # Keep unique Y tensors
+                            if not any(
+                                np.array_equal(data[1].numpy(), unique_label)
+                                for unique_label in unique_labels
+                            ):
+                                unique_labels.append(data[1].numpy())
 
-            ingest_in_tiledb(
-                uri=tiledb_uri_x,
-                data=np.random.rand(*dataset_shape_x),
-                batch_size=BATCH_SIZE,
-            )
-            ingest_in_tiledb(
-                uri=tiledb_uri_y,
-                data=np.random.rand(*dataset_shape_y),
-                batch_size=BATCH_SIZE,
-            )
-
-            with tiledb.DenseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
-                tiledb_uri_y, mode="r"
-            ) as y:
-                with self.assertRaises(Exception):
-                    PyTorchTileDBDenseDataset(
-                        x_array=x, y_array=y, batch_size=BATCH_SIZE
-                    )
+                        self.assertEqual(len(unique_labels), len(unique_inputs))
+                        self.assertEqual(len(unique_inputs) - 1, batchindx)
+                        self.assertEqual(len(unique_labels) - 1, batchindx)

--- a/tests/test_pytorch_dataloader_api.py
+++ b/tests/test_pytorch_dataloader_api.py
@@ -1,0 +1,143 @@
+"""Tests for TileDB integration with Tensorflow Data API."""
+
+import torch
+import tiledb
+import numpy as np
+import unittest
+import tempfile
+
+import torch.nn as nn
+import torch.optim as optim
+
+from tiledb.ml.data_apis.pytorch import PyTorchTileDBDenseDataset
+
+# Test parameters
+NUM_OF_CLASSES = 5
+BATCH_SIZE = 32
+ROWS = 1000
+
+# We test for 2d, 3d, 4d and 5d data
+INPUT_SHAPES = [(10,), (10, 3), (10, 10, 3), (10, 10, 10, 3)]
+
+
+def ingest_in_tiledb(data: np.array, batch_size: int, uri: str):
+    dims = [
+        tiledb.Dim(
+            name="dim_" + str(dim),
+            domain=(0, data.shape[dim] - 1),
+            tile=data.shape[dim] if dim > 0 else batch_size,
+            dtype=np.int32,
+        )
+        for dim in range(data.ndim)
+    ]
+
+    # TileDB schema
+    schema = tiledb.ArraySchema(
+        domain=tiledb.Domain(*dims),
+        sparse=False,
+        attrs=[tiledb.Attr(name="features", dtype=np.float32)],
+    )
+    # Create array
+    tiledb.Array.create(uri, schema)
+
+    # Ingest
+    with tiledb.open(uri, "w") as tiledb_array:
+        tiledb_array[:] = {"features": data}
+
+
+class Net(nn.Module):
+    def __init__(self, shape):
+        super(Net, self).__init__()
+        self.flatten = nn.Flatten()
+        self.linear_relu_stack = nn.Sequential(
+            nn.Linear(np.product(shape), 32),
+            nn.ReLU(),
+            nn.Linear(32, 32),
+            nn.ReLU(),
+            nn.Linear(32, NUM_OF_CLASSES),
+            nn.ReLU(),
+        )
+
+    def forward(self, x):
+        x = self.flatten(x)
+        logits = self.linear_relu_stack(x)
+        return logits
+
+
+class TestTileDBDensePyTorchDataloaderAPI(unittest.TestCase):
+    def test_tiledb_pytorch_data_api_train_with_multiple_dim_data(self):
+        for input_shape in INPUT_SHAPES:
+            with self.subTest():
+                with tempfile.TemporaryDirectory() as tiledb_uri_x, tempfile.TemporaryDirectory() as tiledb_uri_y:
+
+                    dataset_shape_x = (ROWS,) + input_shape
+                    dataset_shape_y = (ROWS,)
+
+                    ingest_in_tiledb(
+                        uri=tiledb_uri_x,
+                        data=np.random.rand(*dataset_shape_x),
+                        batch_size=BATCH_SIZE,
+                    )
+                    ingest_in_tiledb(
+                        uri=tiledb_uri_y,
+                        data=np.random.randint(
+                            low=0, high=NUM_OF_CLASSES, size=dataset_shape_y
+                        ),
+                        batch_size=BATCH_SIZE,
+                    )
+
+                    with tiledb.DenseArray(
+                        tiledb_uri_x, mode="r"
+                    ) as x, tiledb.DenseArray(tiledb_uri_y, mode="r") as y:
+
+                        tiledb_dataset = PyTorchTileDBDenseDataset(
+                            x_array=x, y_array=y, batch_size=BATCH_SIZE
+                        )
+
+                        self.assertIsInstance(
+                            tiledb_dataset, torch.utils.data.IterableDataset
+                        )
+
+                        train_loader = torch.utils.data.DataLoader(
+                            tiledb_dataset, batch_size=None, num_workers=5
+                        )
+
+                        # Train network
+                        net = Net(shape=dataset_shape_x[1:])
+                        criterion = nn.CrossEntropyLoss()
+                        optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
+
+                        for epoch in range(1):  # loop over the dataset multiple times
+                            for inputs, labels in train_loader:
+                                # zero the parameter gradients
+                                optimizer.zero_grad()
+                                # forward + backward + optimize
+                                outputs = net(inputs)
+                                loss = criterion(outputs, labels.type(torch.LongTensor))
+                                loss.backward()
+                                optimizer.step()
+
+    def test_except_with_diff_number_of_x_y_rows(self):
+        with tempfile.TemporaryDirectory() as tiledb_uri_x, tempfile.TemporaryDirectory() as tiledb_uri_y:
+            # Add one extra row on X
+            dataset_shape_x = (ROWS + 1,) + INPUT_SHAPES[0]
+            dataset_shape_y = (ROWS, NUM_OF_CLASSES)
+
+            ingest_in_tiledb(
+                uri=tiledb_uri_x,
+                data=np.random.rand(*dataset_shape_x),
+                batch_size=BATCH_SIZE,
+            )
+            ingest_in_tiledb(
+                uri=tiledb_uri_y,
+                data=np.random.rand(*dataset_shape_y),
+                batch_size=BATCH_SIZE,
+            )
+
+            with tiledb.DenseArray(tiledb_uri_x, mode="r") as x, tiledb.DenseArray(
+                tiledb_uri_y, mode="r"
+            ) as y:
+                with self.assertRaises(Exception):
+                    PyTorchTileDBDenseDataset(
+                        x_array=x, y_array=y, batch_size=BATCH_SIZE
+                    )

--- a/tiledb/ml/data_apis/pytorch.py
+++ b/tiledb/ml/data_apis/pytorch.py
@@ -1,0 +1,62 @@
+"""Functionality for loading data directly from dense TileDB arrays into the PyTorch Dataloader API."""
+import tiledb
+import torch
+import math
+
+
+class PyTorchTileDBDenseDataset(torch.utils.data.IterableDataset):
+    """
+    Class that implements all functionality needed to load data from TileDB directly to the
+    PyTorch Dataloader API.
+    """
+
+    def __init__(self, x_array: tiledb.Array, y_array: tiledb.Array, batch_size: int):
+        """
+        Initialises a PyTorchTileDBDenseDataset that inherits from PyTorch IterableDataset.
+        :param x_array: TileDB Dense Array. Array that contains features.
+        :param y_array: TileDB Dense Array. Array that contains labels.
+        :param batch_size: Integer. The size of the batch that the implemented _generator method will return.
+        For optimal reads from a TileDB array, it is recommended to set the batch size equal to the tile extent of the
+        dimension we query (here, we always query the first dimension of a TileDB array) in order to get a slice (batch)
+        of the data. For example, in case the tile extent of the first dimension of a TileDB array (x or y) is equal to
+        32, it's recommended to set batch_size=32. Any batch size will work, but in case it's not equal the tile extent
+        of the first dimension of the TileDB array, you won't achieve highest read speed. For more details on tiles,
+        tile extent and indices in TileDB, please check here:
+        https://docs.tiledb.com/main/solutions/tiledb-embedded/performance-tips/choosing-tiling-and-cell-layout#dense-arrays
+        """
+
+        # Check that x and y have the same number of rows
+        if x_array.schema.domain.shape[0] != y_array.schema.domain.shape[0]:
+            raise Exception(
+                "X and Y should have the same number of rows, i.e., the 1st dimension "
+                "of TileDB arrays X, Y should be of equal domain extent."
+            )
+
+        self.x = x_array
+        self.y = y_array
+        self.batch_size = batch_size
+
+        # Get number of observations
+        self.rows = x_array.schema.domain.shape[0]
+
+    def __iter__(self):
+        worker_info = torch.utils.data.get_worker_info()
+
+        # single-process data loading, return the full iterator
+        if worker_info is None:
+            iter_start = 0
+            iter_end = self.rows
+
+        # in a worker process split workload
+        else:
+            per_worker = int(math.ceil(self.rows / float(worker_info.num_workers)))
+            worker_id = worker_info.id
+            iter_start = worker_id * per_worker
+            iter_end = min(iter_start + per_worker, self.rows)
+
+        # Loop over batches
+        for offset in range(iter_start, iter_end, self.batch_size):
+            # Yield the next training batch
+            yield self.x[offset : offset + self.batch_size][
+                self.x.schema.attr(0).name
+            ], self.y[offset : offset + self.batch_size][self.y.schema.attr(0).name]

--- a/tiledb/ml/data_apis/pytorch.py
+++ b/tiledb/ml/data_apis/pytorch.py
@@ -42,12 +42,12 @@ class PyTorchTileDBDenseDataset(torch.utils.data.IterableDataset):
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()
 
-        # single-process data loading, return the full iterator
+        # Single worker - return full iterator
         if worker_info is None:
             iter_start = 0
             iter_end = self.rows
 
-        # in a worker process split workload
+        # Multiple workers - split workload
         else:
             per_worker = int(math.ceil(self.rows / float(worker_info.num_workers)))
             worker_id = worker_info.id

--- a/tiledb/ml/data_apis/pytorch.py
+++ b/tiledb/ml/data_apis/pytorch.py
@@ -15,7 +15,8 @@ class PyTorchTileDBDenseDataset(torch.utils.data.IterableDataset):
         Initialises a PyTorchTileDBDenseDataset that inherits from PyTorch IterableDataset.
         :param x_array: TileDB Dense Array. Array that contains features.
         :param y_array: TileDB Dense Array. Array that contains labels.
-        :param batch_size: Integer. The size of the batch that the implemented _generator method will return.
+        :param batch_size: Integer. The size of the batch that the generator will return. Remember to set batch_size=None
+        when calling the PyTorch Dataloader API, because batching is taking place inside the TileDB IterableDataset.
         For optimal reads from a TileDB array, it is recommended to set the batch size equal to the tile extent of the
         dimension we query (here, we always query the first dimension of a TileDB array) in order to get a slice (batch)
         of the data. For example, in case the tile extent of the first dimension of a TileDB array (x or y) is equal to


### PR DESCRIPTION
This PR is about the support of PyTorch Dataloader API. With the implemented functionality, users are able to load data directly from TileDB arrays into the Dataloader API, in order to perform model trainings for supervised machine learning problems. Code added is as follows:

- TileDB-ML/tiledb/ml/data_apis/pytorch.py
- TileDB-ML/tests/test_pytorch_dataloader_api.py

Description:

- The Class that implements all the needed functionality to read data directly from TileDB arrays into Dataloader API, with the use of torch.utils.data.IterableDataset. Specifically, the user can initialise the implemented Class by passing x (tiledb array with features of any dimensionality) and y (tiledb array with labels of any dimensionality), and employ it in order to train a model with PyTorch.
- Unit tests for the aforementioned Class.