### PR TITLE
Example PyTorch Data Api - TileDB Dense Array

### DIFF
--- a/example_notebooks/data_apis/pytorch_data_api_tiledb_dense.ipynb
+++ b/example_notebooks/data_apis/pytorch_data_api_tiledb_dense.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "This example notebook shows how we can train an [image/digit classification](https://pytorch.org/tutorials/beginner/nn_tutorial.html?highlight=mnist)\n",
+    "model based on MNIST dataset, by employing TileDB as a storage engine for our training data and labels. We will first download the MNIST\n",
+    "dataset and ingest images and labels in two dense TileDB arrays. Continuing, we will use our TileDB support for PyTorch Dataloader API\n",
+    "in order to train a image classifier. First, let's import what we need and download our data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import idx2numpy\n",
+    "import numpy as np\n",
+    "import tiledb\n",
+    "import torch\n",
+    "import torchvision\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Download MNIST dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "data = torchvision.datasets.MNIST('./data', train=False, download=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Then we proceed with ingesting images and labels into dense TileDB arrays. Here, we should point out that besides the\n",
+    "flexibility of TileDB in defining a schema, i.e., multiple dimensions, multiple attributes, compression etc,\n",
+    "we choose to define a simple schema. So, for a numpy array of D number of dimensions we create a dense TileDB array,\n",
+    "with the same number of dimensions, and a single attribute of data type numpy float32. Moreover, the\n",
+    "tile extend of the 1st dimension should always be equal with the batch size, in order to achieve optimal reads while\n",
+    "training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Let's define an ingestion function\n",
+    "def ingest_in_tiledb(data: np.array, batch_size: int, uri: str):\n",
+    "    # Equal number of dimensions with the numpy array.\n",
+    "    dims = [\n",
+    "        tiledb.Dim(\n",
+    "            name=\"dim_\" + str(dim),\n",
+    "            domain=(0, data.shape[dim] - 1),\n",
+    "            tile=data.shape[dim] if dim > 0 else batch_size,\n",
+    "            dtype=np.int32,\n",
+    "        )\n",
+    "        for dim in range(data.ndim)\n",
+    "    ]\n",
+    "\n",
+    "    # TileDB schema\n",
+    "    schema = tiledb.ArraySchema(\n",
+    "        domain=tiledb.Domain(*dims),\n",
+    "        sparse=False,\n",
+    "        attrs=[tiledb.Attr(name=\"features\", dtype=data.dtype)],\n",
+    "    )\n",
+    "    # Create array\n",
+    "    tiledb.Array.create(uri, schema)\n",
+    "\n",
+    "    # Ingest\n",
+    "    with tiledb.open(uri, \"w\") as tiledb_array:\n",
+    "        tiledb_array[:] = {\"features\": data}\n",
+    "\n",
+    "images = idx2numpy.convert_from_file('./data/MNIST/raw/train-images-idx3-ubyte')\n",
+    "labels = idx2numpy.convert_from_file('./data/MNIST/raw/train-labels-idx1-ubyte')\n",
+    "\n",
+    "print(images.shape, images.dtype)\n",
+    "print(labels.shape, labels.dtype)\n",
+    "\n",
+    "# Ingest images\n",
+    "ingest_in_tiledb(data=images, batch_size=64, uri='training_images')\n",
+    "\n",
+    "# Ingest labels\n",
+    "ingest_in_tiledb(data=labels, batch_size=64, uri='training_labels')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "We can now explore our TileDB arrays and check their structure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "images_array = tiledb.open('training_images')\n",
+    "labels_array = tiledb.open('training_labels')\n",
+    "\n",
+    "print(images_array.schema)\n",
+    "print(labels_array.schema)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "We can easily now slice our data and create some plots. We can either slice an image or a part of\n",
+    "an image. Because we use only one attribute, we always slice with attribute with index equal to 0.\n",
+    "Some examples below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Plot an image\n",
+    "plt.subplot(1, 2, 1)\n",
+    "plt.imshow(images_array[0][images_array.schema.attr(0).name], cmap=\"gray\")\n",
+    "\n",
+    "# Plot part of the same image\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.imshow(images_array[0, 5:20, 5:20][images_array.schema.attr(0).name], cmap=\"gray\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Let's move on and create a TileDB dataset that can be used with PyTorch Dataloader API for training a machine learning\n",
+    "model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import torch.nn as nn\n",
+    "import torch.optim as optim\n",
+    "\n",
+    "from tiledb.ml.data_apis.pytorch import PyTorchTileDBDenseDataset\n",
+    "\n",
+    "class Net(nn.Module):\n",
+    "    def __init__(self, shape):\n",
+    "        super(Net, self).__init__()\n",
+    "        self.flatten = nn.Flatten()\n",
+    "        self.linear_relu_stack = nn.Sequential(\n",
+    "            nn.Linear(np.product(shape), 32),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Linear(32, 32),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Linear(32, 10),\n",
+    "            nn.ReLU(),\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        x = self.flatten(x)\n",
+    "        logits = self.linear_relu_stack(x)\n",
+    "        return logits\n",
+    "\n",
+    "with tiledb.open('training_images') as x, tiledb.open('training_labels') as y:\n",
+    "    tiledb_dataset = PyTorchTileDBDenseDataset(x_array=x, y_array=y, batch_size=64)\n",
+    "    train_loader = torch.utils.data.DataLoader(tiledb_dataset, batch_size=None, num_workers=2)\n",
+    "\n",
+    "    net = Net(shape=(28, 28))\n",
+    "    criterion = nn.CrossEntropyLoss()\n",
+    "    optimizer = optim.SGD(net.parameters(), lr=0.01, momentum=0.5)\n",
+    "\n",
+    "    for epoch in range(1, 5):\n",
+    "        net.train()\n",
+    "        for batch_idx, (inputs, labels) in enumerate(train_loader):\n",
+    "            # zero the parameter gradients\n",
+    "            optimizer.zero_grad()\n",
+    "            # forward + backward + optimize\n",
+    "            outputs = net(inputs.to(torch.float))\n",
+    "            loss = criterion(outputs, labels.to(torch.float).type(torch.LongTensor))\n",
+    "            loss.backward()\n",
+    "            optimizer.step()\n",
+    "            if batch_idx % 100 == 0:\n",
+    "                print('Train Epoch: {} Batch: {} Loss: {:.6f}'.format(\n",
+    "                epoch, batch_idx, loss.item()))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
This PR is about an example notebook that demonstrates how to train an image classifier by employing our support on the PyTorch Dataloader API. The user is able to check how to ingest data for training in dense TileDB arrays and how to use _PyTorchTileDBDenseDataset_ Class with PyTorch Dataloader in order to train an image classification model.