### PR TITLE
Feature PyTorch Dataloader Support for Sparse TileDB Arrays

### DIFF
--- a/tests/test_pytorch_sparse_dataloader_api.py
+++ b/tests/test_pytorch_sparse_dataloader_api.py
@@ -16,12 +16,12 @@ NUM_OF_CLASSES = 5
 BATCH_SIZE = 20
 ROWS = 1000
 
-# We test for 2d, 3d, 4d and 5d data
-# INPUT_SHAPES = [(10,), (10, 3), (10, 10, 3), (10, 10, 10, 3)]
+# We test for 2d
 INPUT_SHAPES = [
     (10,),
 ]
 # We test for single and multiple workers
+# TODO#1: Multiple workers require tiledb.SparseArray to be pickled hence serializable as well
 NUM_OF_WORKERS = [0]
 
 
@@ -189,6 +189,7 @@ class TestTileDBSparsePyTorchDataloaderAPI(unittest.TestCase):
                         x_array=x, y_array=y, batch_size=BATCH_SIZE
                     )
 
+    # This test is practically skipped but is linked to the TODO#1
     def test_sparse_no_duplicates_with_multiple_workers(self):
         for workers in NUM_OF_WORKERS[2:]:
             with self.subTest():

--- a/tests/test_pytorch_sparse_dataloader_api.py
+++ b/tests/test_pytorch_sparse_dataloader_api.py
@@ -1,0 +1,244 @@
+"""Tests for TileDB integration with Tensorflow Data API."""
+
+import torch
+import tiledb
+import numpy as np
+import unittest
+import tempfile
+
+import torch.nn as nn
+import torch.optim as optim
+
+from tiledb.ml.data_apis.pytorch_sparse import PyTorchTileDBSparseDataset
+
+# Test parameters
+NUM_OF_CLASSES = 5
+BATCH_SIZE = 20
+ROWS = 1000
+
+# We test for 2d, 3d, 4d and 5d data
+# INPUT_SHAPES = [(10,), (10, 3), (10, 10, 3), (10, 10, 10, 3)]
+INPUT_SHAPES = [
+    (10,),
+]
+# We test for single and multiple workers
+NUM_OF_WORKERS = [0]
+
+
+def create_sparse_array_one_hot_2d(rows: int, cols: tuple) -> np.ndarray:
+    seed = np.random.randint(low=0, high=cols[0], size=(rows,))
+    seed[-1] = cols[0] - 1
+    b = np.zeros((seed.size, seed.max() + 1))
+    b[np.arange(seed.size), seed] = 1
+    return b
+
+
+def get_schema(data: np.array, batch_size: int, sparse: bool) -> tiledb.ArraySchema:
+    dims = [
+        tiledb.Dim(
+            name="dim_" + str(dim),
+            domain=(0, data.shape[dim] - 1),
+            tile=data.shape[dim] if dim > 0 else batch_size,
+            dtype=np.int32,
+        )
+        for dim in range(data.ndim)
+    ]
+
+    # TileDB schema
+    schema = tiledb.ArraySchema(
+        domain=tiledb.Domain(*dims),
+        sparse=sparse,
+        attrs=[tiledb.Attr(name="features", dtype=np.float32)],
+    )
+
+    return schema
+
+
+def ingest_in_tiledb(data: np.array, batch_size: int, uri: str):
+    schema = get_schema(data, batch_size, False)
+
+    # Create array
+    tiledb.Array.create(uri, schema)
+
+    # Ingest
+    with tiledb.open(uri, "w") as tiledb_array:
+        tiledb_array[:] = {"features": data}
+
+
+def ingest_in_tiledb_sparse(data: np.array, batch_size: int, uri: str):
+    schema = get_schema(data, batch_size, True)
+
+    # Create the (empty) array on disk.
+    tiledb.Array.create(uri, schema)
+
+    # Ingest
+    with tiledb.open(uri, "w") as tiledb_array:
+        idx = np.nonzero(data)
+        I, J = idx[0], idx[1]
+        tiledb_array[I, J] = {"features": data[idx]}
+
+
+class Net(nn.Module):
+    def __init__(self, shape):
+        super(Net, self).__init__()
+        self.flatten = nn.Flatten()
+        self.linear_relu_stack = nn.Sequential(
+            nn.Linear(np.product(shape), 32),
+            nn.ReLU(),
+            nn.Linear(32, 32),
+            nn.ReLU(),
+            nn.Linear(32, NUM_OF_CLASSES),
+            nn.ReLU(),
+        )
+
+    def forward(self, x):
+        x = self.flatten(x)
+        logits = self.linear_relu_stack(x)
+        return logits
+
+
+class TestTileDBDensePyTorchDataloaderAPI(unittest.TestCase):
+    def test_tiledb_pytorch_data_api_train_with_multiple_dim_data(self):
+        for input_shape in INPUT_SHAPES:
+            for workers in NUM_OF_WORKERS:
+                with self.subTest():
+                    with tempfile.TemporaryDirectory() as tiledb_uri_x, tempfile.TemporaryDirectory() as tiledb_uri_y:
+
+                        dataset_shape_x = (ROWS, input_shape)
+                        dataset_shape_y = (ROWS, (NUM_OF_CLASSES,))
+
+                        ingest_in_tiledb_sparse(
+                            uri=tiledb_uri_x,
+                            data=create_sparse_array_one_hot_2d(
+                                dataset_shape_x[0], dataset_shape_x[1]
+                            ),
+                            batch_size=BATCH_SIZE,
+                        )
+                        ingest_in_tiledb_sparse(
+                            uri=tiledb_uri_y,
+                            data=create_sparse_array_one_hot_2d(
+                                dataset_shape_y[0], dataset_shape_y[1]
+                            ),
+                            batch_size=BATCH_SIZE,
+                        )
+
+                        with tiledb.open(tiledb_uri_x) as x, tiledb.open(
+                            tiledb_uri_y
+                        ) as y:
+
+                            tiledb_dataset = PyTorchTileDBSparseDataset(
+                                x_array=x, y_array=y, batch_size=BATCH_SIZE
+                            )
+
+                            self.assertIsInstance(
+                                tiledb_dataset, torch.utils.data.IterableDataset
+                            )
+
+                            train_loader = torch.utils.data.DataLoader(
+                                tiledb_dataset, batch_size=None, num_workers=workers
+                            )
+
+                            # Train network
+                            net = Net(shape=dataset_shape_x[1:])
+                            # criterion = torch.nn.BCEWithLogitsLoss(pos_weight=torch.tensor(10.))
+                            optimizer = optim.SparseAdam(
+                                net.parameters(),
+                                lr=0.001,
+                                betas=(0.9, 0.999),
+                                eps=1e-08,
+                            )
+
+                            for epoch in range(
+                                1
+                            ):  # loop over the dataset multiple times
+                                for inputs, labels in train_loader:
+                                    # zero the parameter gradients
+                                    optimizer.zero_grad()
+                                    # forward + backward + optimize
+                                    # outputs = net(inputs)
+                                    optimizer.step()
+
+    def test_except_with_diff_number_of_x_y_rows(self):
+        with tempfile.TemporaryDirectory() as tiledb_uri_x, tempfile.TemporaryDirectory() as tiledb_uri_y:
+            # Add one extra row on X
+            dataset_shape_x = (ROWS + 1, INPUT_SHAPES[0])
+            dataset_shape_y = (ROWS, (NUM_OF_CLASSES,))
+
+            ingest_in_tiledb_sparse(
+                uri=tiledb_uri_x,
+                data=create_sparse_array_one_hot_2d(
+                    dataset_shape_x[0], dataset_shape_x[1]
+                ),
+                batch_size=BATCH_SIZE,
+            )
+            ingest_in_tiledb_sparse(
+                uri=tiledb_uri_y,
+                data=create_sparse_array_one_hot_2d(
+                    dataset_shape_y[0], dataset_shape_y[1]
+                ),
+                batch_size=BATCH_SIZE,
+            )
+
+            with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
+                with self.assertRaises(Exception):
+                    PyTorchTileDBSparseDataset(
+                        x_array=x, y_array=y, batch_size=BATCH_SIZE
+                    )
+
+    def test_no_duplicates_with_multiple_workers(self):
+        for workers in NUM_OF_WORKERS[2:]:
+            with self.subTest():
+                with tempfile.TemporaryDirectory() as tiledb_uri_x, tempfile.TemporaryDirectory() as tiledb_uri_y:
+
+                    dataset_shape_x = (ROWS,) + INPUT_SHAPES[1]
+                    dataset_shape_y = (ROWS, (NUM_OF_CLASSES,))
+
+                    ingest_in_tiledb_sparse(
+                        uri=tiledb_uri_x,
+                        data=create_sparse_array_one_hot_2d(
+                            dataset_shape_x[0], dataset_shape_x[1]
+                        ),
+                        batch_size=BATCH_SIZE,
+                    )
+                    ingest_in_tiledb_sparse(
+                        uri=tiledb_uri_y,
+                        data=create_sparse_array_one_hot_2d(
+                            dataset_shape_y[0], dataset_shape_y[1]
+                        ),
+                        batch_size=BATCH_SIZE,
+                    )
+
+                    with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
+
+                        tiledb_dataset = PyTorchTileDBSparseDataset(
+                            x_array=x, y_array=y, batch_size=BATCH_SIZE
+                        )
+
+                        self.assertIsInstance(
+                            tiledb_dataset, torch.utils.data.IterableDataset
+                        )
+
+                        train_loader = torch.utils.data.DataLoader(
+                            tiledb_dataset, batch_size=None, num_workers=workers
+                        )
+
+                        unique_inputs = []
+                        unique_labels = []
+
+                        for batchindx, data in enumerate(train_loader):
+                            # Keep unique X tensors
+                            if not any(
+                                np.array_equal(data[0].numpy(), unique_input)
+                                for unique_input in unique_inputs
+                            ):
+                                unique_inputs.append(data[0].numpy())
+
+                            # Keep unique Y tensors
+                            if not any(
+                                np.array_equal(data[1].numpy(), unique_label)
+                                for unique_label in unique_labels
+                            ):
+                                unique_labels.append(data[1].numpy())
+
+                        self.assertEqual(len(unique_inputs) - 1, batchindx)
+                        self.assertEqual(len(unique_labels) - 1, batchindx)

--- a/tests/test_pytorch_sparse_dataloader_api.py
+++ b/tests/test_pytorch_sparse_dataloader_api.py
@@ -1,4 +1,4 @@
-"""Tests for TileDB integration with Tensorflow Data API."""
+"""Tests for TileDB integration with Pytorch Data API."""
 
 import torch
 import tiledb

--- a/tests/test_pytorch_sparse_dataloader_api.py
+++ b/tests/test_pytorch_sparse_dataloader_api.py
@@ -97,8 +97,8 @@ class Net(nn.Module):
         return logits
 
 
-class TestTileDBDensePyTorchDataloaderAPI(unittest.TestCase):
-    def test_tiledb_pytorch_data_api_train_with_multiple_dim_data(self):
+class TestTileDBSparsePyTorchDataloaderAPI(unittest.TestCase):
+    def test_tiledb_pytorch_sparse_data_api_train_with_multiple_dim_data(self):
         for input_shape in INPUT_SHAPES:
             for workers in NUM_OF_WORKERS:
                 with self.subTest():
@@ -162,7 +162,7 @@ class TestTileDBDensePyTorchDataloaderAPI(unittest.TestCase):
                                     loss.backward()
                                     optimizer.step()
 
-    def test_except_with_diff_number_of_x_y_rows(self):
+    def test_except_with_diff_number_of_x_y_sparse_rows(self):
         with tempfile.TemporaryDirectory() as tiledb_uri_x, tempfile.TemporaryDirectory() as tiledb_uri_y:
             # Add one extra row on X
             dataset_shape_x = (ROWS + 1, INPUT_SHAPES[0])
@@ -189,7 +189,7 @@ class TestTileDBDensePyTorchDataloaderAPI(unittest.TestCase):
                         x_array=x, y_array=y, batch_size=BATCH_SIZE
                     )
 
-    def test_no_duplicates_with_multiple_workers(self):
+    def test_sparse_no_duplicates_with_multiple_workers(self):
         for workers in NUM_OF_WORKERS[2:]:
             with self.subTest():
                 with tempfile.TemporaryDirectory() as tiledb_uri_x, tempfile.TemporaryDirectory() as tiledb_uri_y:

--- a/tiledb/ml/data_apis/pytorch_sparse.py
+++ b/tiledb/ml/data_apis/pytorch_sparse.py
@@ -88,6 +88,9 @@ class PyTorchTileDBSparseDataset(torch.utils.data.IterableDataset):
                 lambda x: x - np.max(x_coords[0]) + self.batch_size - 1
             )(x_coords[0])
 
+            # TODO: Sparse labels are not supported by Pytorch during this iteration for completeness
+            # we support the ingestion of sparseArray in labels, but loss and backward will fail due to
+            # SparseCPU backend
             if self.iter_sparse_label:
                 y_coords = []
                 for i in range(0, self.y.schema.domain.ndim):

--- a/tiledb/ml/data_apis/pytorch_sparse.py
+++ b/tiledb/ml/data_apis/pytorch_sparse.py
@@ -81,7 +81,7 @@ class PyTorchTileDBSparseDataset(torch.utils.data.IterableDataset):
             # to be in the range of [0, self.batch_size] so the torch.sparse.Tensors can be created batch-wise.
             # If we do not normalise the sparse tensor is being created but with a dimension [0, max(coord_index)],
             # which is overkill
-            x_coords[0] -= x_coords[0].max() - self.batch_size + 1
+            x_coords[0] -= x_coords[0].min()
 
             # TODO: Sparse labels are not supported by Pytorch during this iteration for completeness
             # we support the ingestion of sparseArray in labels, but loss and backward will fail due to
@@ -106,7 +106,7 @@ class PyTorchTileDBSparseDataset(torch.utils.data.IterableDataset):
                 # to be in the range of [0, self.batch_size] so the torch.sparse.Tensors can be created batch-wise.
                 # If we do not normalise the sparse tensor is being created but with a dimension [0, max(coord_index)],
                 # which is overkill
-                y_coords[0] -= y_coords[0].max() - self.batch_size + 1
+                y_coords[0] -= y_coords[0].min()
 
                 y_tensor = torch.sparse_coo_tensor(
                     torch.tensor(list(zip(*y_coords))).t(),

--- a/tiledb/ml/data_apis/pytorch_sparse.py
+++ b/tiledb/ml/data_apis/pytorch_sparse.py
@@ -1,0 +1,105 @@
+"""Functionality for loading data directly from dense TileDB arrays into the PyTorch Dataloader API."""
+import tiledb
+import torch
+import math
+import numpy as np
+
+
+class PyTorchTileDBSparseDataset(torch.utils.data.IterableDataset):
+    """
+    Class that implements all functionality needed to load data from TileDB directly to the
+    PyTorch Dataloader API.
+    """
+
+    def __init__(self, x_array: tiledb.Array, y_array: tiledb.Array, batch_size: int):
+        """
+        Initialises a PyTorchTileDBSparseDataset that inherits from PyTorch IterableDataset.
+        :param x_array: TileDB Dense Array. Array that contains features.
+        :param y_array: TileDB Dense Array. Array that contains labels.
+        :param batch_size: Integer. The size of the batch that the generator will return. Remember to set batch_size=None
+        when calling the PyTorch Dataloader API, because batching is taking place inside the TileDB IterableDataset.
+        """
+
+        # Check that x and y have the same number of rows
+        if x_array.schema.domain.shape[0] != y_array.schema.domain.shape[0]:
+            raise ValueError(
+                "X and Y should have the same number of rows, i.e., the 1st dimension "
+                "of TileDB arrays X, Y should be of equal domain extent."
+            )
+
+        self.x = x_array
+        self.y = y_array
+        self.batch_size = batch_size
+
+    def __iter__(self):
+        worker_info = torch.utils.data.get_worker_info()
+
+        # Get number of observations
+        rows = self.x.schema.domain.shape[0]
+
+        # Single worker - return full iterator
+        if worker_info is None:
+            iter_start = 0
+            iter_end = rows
+
+        # Multiple workers - split workload
+        else:
+            per_worker = int(math.ceil(rows / worker_info.num_workers))
+            worker_id = worker_info.id
+            iter_start = worker_id * per_worker
+            iter_end = min(iter_start + per_worker, rows)
+
+        # x_attr_name = self.x.schema.attr(0).name
+        # y_attr_name = self.y.schema.attr(0).name
+
+        x_shape = self.x.schema.domain.shape[1:]
+        y_shape = self.y.schema.domain.shape[1:]
+
+        # Loop over batches
+        for offset in range(iter_start, iter_end, self.batch_size):
+            # Yield the next training batch
+            y_batch = self.y[offset : offset + self.batch_size]
+            x_batch = self.x[offset : offset + self.batch_size]
+
+            # TODO: Both for dense case support multiple attributes
+            values_y = list(y_batch.items())[0][1]
+            values_x = list(x_batch.items())[0][1]
+
+            # Transform to TF COO format y data
+            y_data = np.array(values_y).ravel()
+            x_data = np.array(values_x).ravel()
+            if x_data.shape[0] != y_data.shape[0]:
+                raise ValueError(
+                    "X and Y should have the same number of rows, i.e., the 1st dimension "
+                    "of TileDB arrays X, Y should be of equal domain extent inside the batch"
+                )
+
+            y_coords = []
+            for i in range(0, self.y.schema.domain.ndim):
+                dim_name = self.y.schema.domain.dim(i).name
+                y_coords.append(np.array(y_batch[dim_name]))
+
+            # Transform to TF COO format x data
+            x_coords = []
+            for i in range(0, self.x.schema.domain.ndim):
+                dim_name = self.x.schema.domain.dim(i).name
+                x_coords.append(np.array(x_batch[dim_name]))
+
+            x_coords[0] = np.vectorize(
+                lambda x: x - np.max(x_coords[0]) + self.batch_size - 1
+            )(x_coords[0])
+            y_coords[0] = np.vectorize(
+                lambda y: y - np.max(y_coords[0]) + self.batch_size - 1
+            )(y_coords[0])
+
+            yield torch.sparse_coo_tensor(
+                torch.tensor(list(zip(*x_coords))).t(),
+                x_data,
+                (self.batch_size, x_shape[0]),
+                requires_grad=False,
+            ), torch.sparse_coo_tensor(
+                torch.tensor(list(zip(*y_coords))).t(),
+                y_data,
+                (self.batch_size, y_shape[0]),
+                requires_grad=True,
+            )

--- a/tiledb/ml/data_apis/pytorch_sparse.py
+++ b/tiledb/ml/data_apis/pytorch_sparse.py
@@ -1,8 +1,7 @@
-"""Functionality for loading data directly from dense TileDB arrays into the PyTorch Dataloader API."""
+"""Functionality for loading data directly from sparse TileDB arrays into the PyTorch Dataloader API."""
 import tiledb
 import torch
 import math
-import numpy as np
 
 
 class PyTorchTileDBSparseDataset(torch.utils.data.IterableDataset):
@@ -14,8 +13,9 @@ class PyTorchTileDBSparseDataset(torch.utils.data.IterableDataset):
     def __init__(self, x_array: tiledb.Array, y_array: tiledb.Array, batch_size: int):
         """
         Initialises a PyTorchTileDBSparseDataset that inherits from PyTorch IterableDataset.
-        :param x_array: TileDB Dense Array. Array that contains features.
-        :param y_array: TileDB Dense Array. Array that contains labels.
+        :param x_array: TileDB Sparse Array. Array that contains features.
+        :param y_array: TileDB Sparse/Dense Array. Array that contains labels. The sparse tiledb arrays are ingested in sparse
+        tensors but torch does not provide full functionality (experimented) for this case.
         :param batch_size: Integer. The size of the batch that the generator will return. Remember to set batch_size=None
         when calling the PyTorch Sparse Dataloader API, because batching is taking place inside the TileDB IterableDataset.
         """
@@ -31,25 +31,19 @@ class PyTorchTileDBSparseDataset(torch.utils.data.IterableDataset):
         self.y = y_array
         self.batch_size = batch_size
 
-        if isinstance(y_array, tiledb.SparseArray):
-            self.iter_sparse_label = True
-        else:
-            self.iter_sparse_label = False
-
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()
 
         # Get number of observations
         rows = self.x.schema.domain.shape[0]
 
-        # Single worker - return full iterator
         if worker_info is None:
+            # Single worker - return full iterator
             iter_start = 0
             iter_end = rows
-
-        # Multiple workers - split workload
         else:
-            per_worker = int(math.ceil(rows / worker_info.num_workers))
+            # Multiple workers - split workload
+            per_worker = math.ceil(rows / worker_info.num_workers)
             worker_id = worker_info.id
             iter_start = worker_id * per_worker
             iter_end = min(iter_start + per_worker, rows)
@@ -62,16 +56,16 @@ class PyTorchTileDBSparseDataset(torch.utils.data.IterableDataset):
         # Loop over batches
         for offset in range(iter_start, iter_end, self.batch_size):
             # Yield the next training batch
-            y_batch = self.y[offset : offset + self.batch_size]
             x_batch = self.x[offset : offset + self.batch_size]
+            y_batch = self.y[offset : offset + self.batch_size]
 
             # TODO: Both for dense case support multiple attributes
-            values_y = list(y_batch.items())[0][1]
             values_x = list(x_batch.items())[0][1]
+            values_y = list(y_batch.items())[0][1]
 
             # Transform to TF COO format y data
-            y_data = np.array(values_y).ravel()
-            x_data = np.array(values_x).ravel()
+            x_data = values_x.ravel()
+            y_data = values_y.ravel()
             if x_data.shape[0] != y_data.shape[0]:
                 raise ValueError(
                     "X and Y should have the same number of rows, i.e., the 1st dimension "
@@ -81,42 +75,46 @@ class PyTorchTileDBSparseDataset(torch.utils.data.IterableDataset):
             x_coords = []
             for i in range(0, self.x.schema.domain.ndim):
                 dim_name = self.x.schema.domain.dim(i).name
-                x_coords.append(np.array(x_batch[dim_name]))
+                x_coords.append(x_batch[dim_name])
 
-            # Normalise indices for torch.sparse.Tensor are batched with 0-index
-            x_coords[0] = np.vectorize(
-                lambda x: x - np.max(x_coords[0]) + self.batch_size - 1
-            )(x_coords[0])
+            # Normalise indices for torch.sparse.Tensor We want the coords indices in every iteration
+            # to be in the range of [0, self.batch_size] so the torch.sparse.Tensors can be created batch-wise.
+            # If we do not normalise the sparse tensor is being created but with a dimension [0, max(coord_index)],
+            # which is overkill
+            x_coords[0] -= x_coords[0].max() - self.batch_size + 1
 
             # TODO: Sparse labels are not supported by Pytorch during this iteration for completeness
             # we support the ingestion of sparseArray in labels, but loss and backward will fail due to
             # SparseCPU backend
-            if self.iter_sparse_label:
+
+            # Identify the label array hence ingest it as sparse tensor or simple tensor
+
+            x_tensor = torch.sparse_coo_tensor(
+                torch.tensor(list(zip(*x_coords))).t(),
+                x_data,
+                (self.batch_size, x_shape[0]),
+                requires_grad=False,
+            )
+
+            if isinstance(self.y, tiledb.SparseArray):
                 y_coords = []
                 for i in range(0, self.y.schema.domain.ndim):
                     dim_name = self.y.schema.domain.dim(i).name
-                    y_coords.append(np.array(y_batch[dim_name]))
+                    y_coords.append(y_batch[dim_name])
 
-                # Normalise indices for torch.sparse.Tensor are batched with 0-index
-                y_coords[0] = np.vectorize(
-                    lambda y: y - np.max(y_coords[0]) + self.batch_size - 1
-                )(y_coords[0])
+                # Normalise indices for torch.sparse.Tensor We want the coords indices in every iteration
+                # to be in the range of [0, self.batch_size] so the torch.sparse.Tensors can be created batch-wise.
+                # If we do not normalise the sparse tensor is being created but with a dimension [0, max(coord_index)],
+                # which is overkill
+                y_coords[0] -= y_coords[0].max() - self.batch_size + 1
 
-                yield torch.sparse_coo_tensor(
-                    torch.tensor(list(zip(*x_coords))).t(),
-                    x_data,
-                    (self.batch_size, x_shape[0]),
-                    requires_grad=False,
-                ), torch.sparse_coo_tensor(
+                y_tensor = torch.sparse_coo_tensor(
                     torch.tensor(list(zip(*y_coords))).t(),
                     y_data,
                     (self.batch_size, y_shape[0]),
                     requires_grad=False,
                 )
             else:
-                yield torch.sparse_coo_tensor(
-                    torch.tensor(list(zip(*x_coords))).t(),
-                    x_data,
-                    (self.batch_size, x_shape[0]),
-                    requires_grad=False,
-                ), self.y[offset : offset + self.batch_size][y_attr_name]
+                y_tensor = self.y[offset : offset + self.batch_size][y_attr_name]
+
+            yield x_tensor, y_tensor


### PR DESCRIPTION
This PR is about the support of PyTorch Sparse Dataloader API. With the implemented functionality, users are able to load data directly from TileDB sparse arrays into the Sparse Dataloader API, in order to perform model trainings for supervised machine learning problems. Code added is as follows:

```
TileDB-ML/tiledb/ml/data_apis/pytorch_sparse.py
TileDB-ML/tests/test_pytorch_sparse_dataloader_api.py
```

**Description:**

The Class that implements all the needed functionality to read data directly from TileDB sparse arrays into Sparse Dataloader API, with the use of `torch.utils.data.IterableDataset`. Specifically, the user can initialise the implemented Class by passing `x` _(sparse tiledb array with features of dim=2)_. 2D Dimension for sparse array is what is tested in this PR as constructing an `nd-sparse array` might require external libraries only for testing. We support the basic scenario and upon requests we expand to `ND` **w.l.o.g**. and `y` _(tiledb array with labels of any dimensionality)_, and employ it in order to train a model with PyTorch. For `labels: y` we support ingestion both for sparse arrays but also `dense labels`. Sparse `labels` are not yet supported in `Pytorch` framework with many open issues still to be closed and thus model training will not be feasible due to the lack of support for `losses, backward pass ...`. Also as described in `TODO` comments of the PR code we need to investigate the serialisability of `tilebd.SparseArray` in `Tiledb-Py` for supporting multiple workers as `torch` requires it. 

Unit tests for the aforementioned Class.