### PR TITLE
[Enhancement] Implemented __len__() for TF and PyTorch Dense APIs Support

### DIFF
--- a/tests/test_pytorch_dataloader_api.py
+++ b/tests/test_pytorch_dataloader_api.py
@@ -205,3 +205,28 @@ class TestTileDBDensePyTorchDataloaderAPI(unittest.TestCase):
 
                         self.assertEqual(len(unique_inputs) - 1, batchindx)
                         self.assertEqual(len(unique_labels) - 1, batchindx)
+
+    def test_dataset_length(self):
+        with tempfile.TemporaryDirectory() as tiledb_uri_x, tempfile.TemporaryDirectory() as tiledb_uri_y:
+            dataset_shape_x = (ROWS,) + INPUT_SHAPES[1]
+            dataset_shape_y = (ROWS,)
+
+            ingest_in_tiledb(
+                uri=tiledb_uri_x,
+                data=np.random.rand(*dataset_shape_x),
+                batch_size=BATCH_SIZE,
+            )
+            ingest_in_tiledb(
+                uri=tiledb_uri_y,
+                data=np.random.randint(
+                    low=0, high=NUM_OF_CLASSES, size=dataset_shape_y
+                ),
+                batch_size=BATCH_SIZE,
+            )
+
+            with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
+                tiledb_dataset = PyTorchTileDBDenseDataset(
+                    x_array=x, y_array=y, batch_size=BATCH_SIZE
+                )
+
+                self.assertEqual(len(tiledb_dataset), ROWS)

--- a/tests/test_tensorflow_data_api.py
+++ b/tests/test_tensorflow_data_api.py
@@ -134,3 +134,31 @@ class TestTileDBTensorflowDataAPI(test.TestCase):
                 TensorflowTileDBDenseDataset(
                     x_array=x, y_array=y, batch_size=BATCH_SIZE
                 )
+
+    @testing_utils.run_v2_only
+    def test_dataset_length(self):
+        array_uuid = str(uuid.uuid4())
+        tiledb_uri_x = os.path.join(self.get_temp_dir(), "x" + array_uuid)
+        tiledb_uri_y = os.path.join(self.get_temp_dir(), "y" + array_uuid)
+
+        # Add one extra row on X
+        dataset_shape_x = (ROWS,) + INPUT_SHAPES[0]
+        dataset_shape_y = (ROWS, NUM_OF_CLASSES)
+
+        ingest_in_tiledb(
+            uri=tiledb_uri_x,
+            data=np.random.rand(*dataset_shape_x),
+            batch_size=BATCH_SIZE,
+        )
+        ingest_in_tiledb(
+            uri=tiledb_uri_y,
+            data=np.random.rand(*dataset_shape_y),
+            batch_size=BATCH_SIZE,
+        )
+
+        with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
+            tiledb_dataset = TensorflowTileDBDenseDataset(
+                x_array=x, y_array=y, batch_size=BATCH_SIZE
+            )
+
+            self.assertEqual(len(tiledb_dataset), ROWS)

--- a/tiledb/ml/data_apis/pytorch.py
+++ b/tiledb/ml/data_apis/pytorch.py
@@ -64,3 +64,6 @@ class PyTorchTileDBDenseDataset(torch.utils.data.IterableDataset):
             yield self.x[offset : offset + self.batch_size][x_attr_name], self.y[
                 offset : offset + self.batch_size
             ][y_attr_name]
+
+    def __len__(self):
+        return self.x.shape[0]


### PR DESCRIPTION
This PR is about the support of __len__() in both Tensorflow and PyTorch data API support with Dense TileDB arrays. Now the users will be able to get the length of a **TensorflowTileDBDenseDataset** or **PyTorchTileDBDenseDataset** by employing Python's _len()_. 

Special thanks to @gsakkis for the tips in Class reassignment. 