### PR TITLE
Update tensorflow version to 2.5 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ tiledb>=0.8.5
 torch>=1.8.1
 scikit-learn>=0.23.0
 torchvision>=0.9.1
-tensorflow>=2.2.0,<=2.4.0
+tensorflow>=2.5.0

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
         "torch>=1.8.1",
         "scikit-learn>=0.23.0",
         "torchvision>=0.9.1",
-        "tensorflow>=2.2.0,<=2.4.0",
+        "tensorflow>=2.5.0",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
We have to update our tensorflow version support to 2.5 because of a [serious security vulnerability](https://github.com/advisories/GHSA-cwv3-863g-39vx).

