### PR TITLE
[BugFix] Checking row dimension between x and y for TF implementation

### DIFF
--- a/tests/test_tensorflow_sparse_data_api.py
+++ b/tests/test_tensorflow_sparse_data_api.py
@@ -151,6 +151,7 @@ class TestTileDBTensorflowSparseDataAPI(test.TestCase):
                     uri=tiledb_uri_y,
                     data=np.random.rand(*dataset_shape_y),
                     batch_size=BATCH_SIZE,
+                    sparse=False,
                 )
 
                 with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:


### PR DESCRIPTION
This bugfix concerns the check for same row dimensionality of x, y in `TensorflowTileDBSparseDataset`. The new check takes into consideration that the sparse array x can have multiple values per row. It now checks between unique coords instead of just data which in sparse case are the non-zero values causing different shapes between sparse X and dense Y.

Also a second fix concerns the normalization of `x` and `y` coords inside the generator. During training there is a conflict inside TF framework on how `SparseTensors` are declared. Having coords `indices` with values not in the region of dense shape creates the problem. So if we want to use "small" `SparseTensors` with dense shape [batch_size, num_of_features] then we have to normalise the rows indices to [0, batch_size). This fix does exactly that and it is the same principle of how `Pytorch` also handles it.