### PR TITLE
[Enhancement] Adding test coverage stats and repo badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
-name: TileDB-ML Python CI
+name: TileDB-ML CI
 
 on: [push]
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -39,6 +38,29 @@ jobs:
       run: pip install -e .[full]
       shell: bash
 
-    - name: 'Run tests'
+    - name: 'Run test coverage statistics'
+      id: stats
+      shell: bash
       run: |
-        pytest -q tests
+        pip install pytest-cov
+        TEST_COVERAGE="$(pytest --cov-report term:skip-covered --cov=tiledb tests/ | grep '^TOTAL' | awk -v N=4 '{print $N}')"
+        echo "::set-output name=COVERAGE::$TEST_COVERAGE"
+        REF=${{ github.ref }}
+        echo "github.ref: $REF"
+        IFS='/' read -ra PATHS <<< "$REF"
+        BRANCH_NAME="${PATHS[1]}_${PATHS[2]}"
+        echo $BRANCH_NAME
+        echo $TEST_COVERAGE
+        echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
+
+    - name: 'Create the Badge'
+      if: ${{ matrix.os == 'macos-latest' && matrix.python-version == '3.6' }}
+      uses: schneegans/dynamic-badges-action@v1.0.0
+      with:
+        auth: ${{ secrets.COVERAGE_SECRET }}
+        gistID: 2506f6c9d3375e2d636cf594340d11bf
+        filename: gistfile.json
+        label: coverage
+        message: ${{ steps.stats.outputs.COVERAGE }}
+        color: green
+        namedLogo: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         echo $TEST_COVERAGE
         echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
 
-    - name: 'Create the Badge'
+    - name: 'Create Test Coverage Badge'
       if: ${{ matrix.os == 'macos-latest' && matrix.python-version == '3.6' }}
       uses: schneegans/dynamic-badges-action@v1.0.0
       with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <a href="https://tiledb.com"><img src="https://github.com/TileDB-Inc/TileDB/raw/dev/doc/source/_static/tiledb-logo_color_no_margin_@4x.png" alt="TileDB logo" width="400"></a>
 
+[![TileDB-ML CI](https://github.com/TileDB-Inc/TileDB-ML/actions/workflows/ci.yml/badge.svg)](https://github.com/TileDB-Inc/TileDB-ML/actions/workflows/ci.yml)
+![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ktsitsi/2506f6c9d3375e2d636cf594340d11bf/raw/gistfile.json)
+
 # TileDB-ML
 
 TileDB-ML is the repository that contains all machine learning oriented functionality TileDB supports. In this repo, we explain how someone can employ 


### PR DESCRIPTION
This PR concerns improvements for TILEDB-ML repo [ch7298]. We change the CI job for testing with `pytest` so it provides test coverage stats. We also create a gist badge for coverage in `README.md`. The badge is set to run only from one CI runner.

Changed files:

```
.github/workflows/ci.yaml
README.md
```