### PR TITLE
Load models at specific timestamp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     },
     test_suite="tests",
     install_requires=[
-        "tiledb>=0.8.5, <=0.8.9",
+        "tiledb>=0.9.0",
     ],
     extras_require={
         "tensorflow": ["tensorflow>=2.5.0"],

--- a/tiledb/ml/models/pytorch.py
+++ b/tiledb/ml/models/pytorch.py
@@ -6,7 +6,7 @@ import json
 import numpy as np
 import tiledb
 
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch
 from torch.optim import Optimizer
@@ -49,14 +49,17 @@ class PyTorchTileDB(TileDBModel):
         self._write_array(serialized_model_info=serialized_model_info, meta=meta)
 
     def load(
-        self, model: Module, optimizer: Optimizer, timestamp: Optional[int] = None
+        self,
+        model: Module,
+        optimizer: Optimizer,
+        timestamp: Optional[Tuple[int, int]] = None,
     ) -> dict:
         """
         Loads a PyTorch model from a TileDB array.
         :param model: Pytorch Module. A defined PyTorch model.
         :param optimizer: PyTorch Optimizer. A defined PyTorch optimizer.
-        :param timestamp: Int. In case we want to use TileDB time travelling, we can provide a
-        specific timestamp in order to load a specific fragment of the array.
+        :param timestamp: Tuple of int. In case we want to use TileDB time travelling, we can provide a range of
+        timestamps in order to load fragments of the array which live in the specified time range.
         :return: Dict. A dictionary with attributes other than model or optimizer
         state_dict.
         """

--- a/tiledb/ml/models/pytorch.py
+++ b/tiledb/ml/models/pytorch.py
@@ -48,15 +48,19 @@ class PyTorchTileDB(TileDBModel):
 
         self._write_array(serialized_model_info=serialized_model_info, meta=meta)
 
-    def load(self, model: Module, optimizer: Optimizer) -> dict:
+    def load(
+        self, model: Module, optimizer: Optimizer, timestamp: Optional[int] = None
+    ) -> dict:
         """
         Loads a PyTorch model from a TileDB array.
         :param model: Pytorch Module. A defined PyTorch model.
         :param optimizer: PyTorch Optimizer. A defined PyTorch optimizer.
+        :param timestamp: Int. In case we want to use TileDB time travelling, we can provide a
+        specific timestamp in order to load a specific fragment of the array.
         :return: Dict. A dictionary with attributes other than model or optimizer
         state_dict.
         """
-        model_array = tiledb.open(self.uri, ctx=self.ctx)
+        model_array = tiledb.open(self.uri, ctx=self.ctx, timestamp=timestamp)
         model_array_results = model_array[:]
         schema = model_array.schema
 

--- a/tiledb/ml/models/sklearn.py
+++ b/tiledb/ml/models/sklearn.py
@@ -7,7 +7,7 @@ import json
 import tiledb
 import tiledb.cloud
 
-from typing import Optional
+from typing import Optional, Tuple
 
 import sklearn
 from sklearn.base import BaseEstimator
@@ -47,11 +47,11 @@ class SklearnTileDB(TileDBModel):
 
         self._write_array(serialized_model=serialized_model, meta=meta)
 
-    def load(self, timestamp: Optional[int] = None) -> BaseEstimator:
+    def load(self, timestamp: Optional[Tuple[int, int]] = None) -> BaseEstimator:
         """
         Loads a Sklearn model from a TileDB array.
-        :param timestamp: Int. In case we want to use TileDB time travelling, we can provide a
-        specific timestamp in order to load a specific fragment of the array.
+        :param timestamp: Tuple of int. In case we want to use TileDB time travelling, we can provide a range of
+        timestamps in order to load fragments of the array which live in the specified time range.
         :return: BaseEstimator. A Sklearn model object.
         """
         model_array = tiledb.open(self.uri, ctx=self.ctx, timestamp=timestamp)

--- a/tiledb/ml/models/sklearn.py
+++ b/tiledb/ml/models/sklearn.py
@@ -47,11 +47,14 @@ class SklearnTileDB(TileDBModel):
 
         self._write_array(serialized_model=serialized_model, meta=meta)
 
-    def load(self) -> BaseEstimator:
+    def load(self, timestamp: Optional[int] = None) -> BaseEstimator:
         """
         Loads a Sklearn model from a TileDB array.
+        :param timestamp: Int. In case we want to use TileDB time travelling, we can provide a
+        specific timestamp in order to load a specific fragment of the array.
+        :return: BaseEstimator. A Sklearn model object.
         """
-        model_array = tiledb.open(self.uri, ctx=self.ctx)
+        model_array = tiledb.open(self.uri, ctx=self.ctx, timestamp=timestamp)
         model_array_results = model_array[:]
         model = pickle.loads(model_array_results["model_params"].item(0))
         return model

--- a/tiledb/ml/models/tensorflow.py
+++ b/tiledb/ml/models/tensorflow.py
@@ -73,16 +73,21 @@ class TensorflowTileDB(TileDBModel):
         )
 
     def load(
-        self, compile_model: bool = False, custom_objects: Optional[dict] = None
+        self,
+        compile_model: bool = False,
+        custom_objects: Optional[dict] = None,
+        timestamp: Optional[int] = None,
     ) -> Model:
         """
         Loads a Tensorflow model from a TileDB array.
         :param compile_model: Boolean. Whether to compile the model after loading or not.
         :param custom_objects: Optional dictionary mapping names (strings) to
         custom classes or functions to be considered during deserialization.
+        :param timestamp: Int. In case we want to use TileDB time travelling, we can provide a
+        specific timestamp in order to load a specific fragment of the array.
         :return: Model. Tensorflow model.
         """
-        model_array = tiledb.open(self.uri, ctx=self.ctx)
+        model_array = tiledb.open(self.uri, ctx=self.ctx, timestamp=timestamp)
         model_array_results = model_array[:]
         model_weights = pickle.loads(model_array_results["model_weights"].item(0))
         model_config = json.loads(model_array.meta["model_config"])

--- a/tiledb/ml/models/tensorflow.py
+++ b/tiledb/ml/models/tensorflow.py
@@ -8,7 +8,7 @@ import numpy as np
 import tensorflow as tf
 import tiledb
 
-from typing import Optional
+from typing import Optional, Tuple
 
 from tensorflow.python.keras.models import Model, Sequential
 from tensorflow.python.keras.engine.functional import Functional
@@ -76,15 +76,15 @@ class TensorflowTileDB(TileDBModel):
         self,
         compile_model: bool = False,
         custom_objects: Optional[dict] = None,
-        timestamp: Optional[int] = None,
+        timestamp: Optional[Tuple[int, int]] = None,
     ) -> Model:
         """
         Loads a Tensorflow model from a TileDB array.
         :param compile_model: Boolean. Whether to compile the model after loading or not.
         :param custom_objects: Optional dictionary mapping names (strings) to
         custom classes or functions to be considered during deserialization.
-        :param timestamp: Int. In case we want to use TileDB time travelling, we can provide a
-        specific timestamp in order to load a specific fragment of the array.
+        :param timestamp: Tuple of int. In case we want to use TileDB time travelling, we can provide a range of
+        timestamps in order to load fragments of the array which live in the specified time range.
         :return: Model. Tensorflow model.
         """
         model_array = tiledb.open(self.uri, ctx=self.ctx, timestamp=timestamp)


### PR DESCRIPTION
This PR is about supporting time travelling on machine learning models saved as TileDB arrays. We just have to give users the ability to pass a timestamp argument while loading a model, and the rest is on TileDB-Py to load the correct fragment of the model array.