### PR TITLE
[Hotfix] Fixing cloud import in models base

### DIFF
--- a/tiledb/ml/models/base.py
+++ b/tiledb/ml/models/base.py
@@ -2,9 +2,7 @@
 
 import abc
 import os
-import tiledb.cloud
-
-from tiledb.ml._cloud_utils import get_s3_prefix
+import tiledb
 
 
 class TileDBModel(abc.ABC):
@@ -29,6 +27,8 @@ class TileDBModel(abc.ABC):
 
         # In case we work on TileDB-Cloud we need user's namespace.
         if self.namespace:
+            from tiledb.ml._cloud_utils import get_s3_prefix
+
             s3_prefix = get_s3_prefix(self.namespace)
             if s3_prefix is None:
                 raise ValueError(


### PR DESCRIPTION
We give the opportunity with `extra_requires` in the `setup.py` for specific installation based on the ML framework. The hotfix relates to these PRs #53 and #54 ,  the global import on the base model class was erroring out the local installations e.g. `pip install -e tiledb-ml[pytorch]`, which according the `setup.py` does not require `tiledb-cloud` 

```
"pytorch": ["torch>=1.8.1", "torchvision>=0.9.1"],
```

Files changed:

`tiledb/ml/models/base.py` 