### PR TITLE
[Feature] Changes for supporting model preview for all frameworks

### DIFF
--- a/tests/test_pytorch_models.py
+++ b/tests/test_pytorch_models.py
@@ -144,5 +144,5 @@ def test_preview(tmpdir, net):
     tiledb_array = os.path.join(tmpdir, "model_array")
     tiledb_obj = PyTorchTileDB(uri=tiledb_array)
     saved_net = net()
+    print(tiledb_obj.preview(saved_net))
     assert type(tiledb_obj.preview(saved_net)) == str
-    assert tiledb_obj.preview(saved_net) is not None

--- a/tests/test_pytorch_models.py
+++ b/tests/test_pytorch_models.py
@@ -130,3 +130,19 @@ def test_save(tmpdir, net, optimizer):
         saved_optimizer.state_dict().items(), loaded_optimizer.state_dict().items()
     ):
         assert all([a == b for a, b in zip(key_item_1[1], key_item_2[1])])
+
+
+@pytest.mark.parametrize(
+    "net",
+    [
+        getattr(sys.modules[__name__], name)
+        for name, obj in inspect.getmembers(sys.modules[__name__])
+        if inspect.isclass(obj) and obj.__module__ == __name__
+    ],
+)
+def test_preview(tmpdir, net):
+    tiledb_array = os.path.join(tmpdir, "model_array")
+    tiledb_obj = PyTorchTileDB(uri=tiledb_array)
+    saved_net = net()
+    assert type(tiledb_obj.preview(saved_net)) == str
+    assert tiledb_obj.preview(saved_net) is not None

--- a/tests/test_sklearn_models.py
+++ b/tests/test_sklearn_models.py
@@ -33,5 +33,5 @@ def test_preview(tmpdir, net):
     tiledb_array = os.path.join(tmpdir, "test_array")
     model = net()
     tiledb_sklearn_obj = SklearnTileDB(uri=tiledb_array)
+    print(tiledb_sklearn_obj.preview(model))
     assert type(tiledb_sklearn_obj.preview(model)) == str
-    assert tiledb_sklearn_obj.preview(model) is not None

--- a/tests/test_sklearn_models.py
+++ b/tests/test_sklearn_models.py
@@ -23,3 +23,15 @@ def test_save_load(tmpdir, net):
     tiledb_sklearn_obj.save(model=model)
     loaded_model = tiledb_sklearn_obj.load()
     assert all([a == b for a, b in zip(model.get_params(), loaded_model.get_params())])
+
+
+@pytest.mark.parametrize(
+    "net",
+    list(iter_models("svm", "linear_model", "naive_bayes", "tree")),
+)
+def test_preview(tmpdir, net):
+    tiledb_array = os.path.join(tmpdir, "test_array")
+    model = net()
+    tiledb_sklearn_obj = SklearnTileDB(uri=tiledb_array)
+    assert type(tiledb_sklearn_obj.preview(model)) == str
+    assert tiledb_sklearn_obj.preview(model) is not None

--- a/tests/test_tensorflow_keras_models.py
+++ b/tests/test_tensorflow_keras_models.py
@@ -390,7 +390,6 @@ class TestTensorflowKerasModel:
         tiledb_model_obj = TensorflowTileDB(uri=tiledb_uri)
         if model.built:
             assert type(tiledb_model_obj.preview(model)) == str
-            assert tiledb_model_obj.preview(model) is not None
         else:
             # Model should be built before preview it
             with pytest.raises(ValueError):

--- a/tiledb/ml/models/base.py
+++ b/tiledb/ml/models/base.py
@@ -4,7 +4,6 @@ import abc
 import os
 import tiledb
 import typing
-from functools import singledispatchmethod
 
 
 class TileDBModel(abc.ABC):
@@ -60,7 +59,7 @@ class TileDBModel(abc.ABC):
         Must be implemented per machine learning framework.
         """
 
-    @singledispatchmethod
+    @abc.abstractmethod
     def preview(self, model: typing.Any, **kwargs):
         """
         Abstract method that previews a machine learning model.

--- a/tiledb/ml/models/base.py
+++ b/tiledb/ml/models/base.py
@@ -3,6 +3,8 @@
 import abc
 import os
 import tiledb
+import typing
+from functools import singledispatchmethod
 
 
 class TileDBModel(abc.ABC):
@@ -58,10 +60,12 @@ class TileDBModel(abc.ABC):
         Must be implemented per machine learning framework.
         """
 
-    @abc.abstractmethod
-    def preview(self, **kwargs):
+    @singledispatchmethod
+    def preview(self, model: typing.Any, **kwargs):
         """
         Abstract method that previews a machine learning model.
         Must be implemented per machine learning framework, i.e, Tensorflow,
         PyTorch etc.
         """
+
+        raise NotImplementedError("Preview method is not implemented")

--- a/tiledb/ml/models/base.py
+++ b/tiledb/ml/models/base.py
@@ -57,3 +57,11 @@ class TileDBModel(abc.ABC):
         Abstract method that loads a machine learning model from a model TileDB array.
         Must be implemented per machine learning framework.
         """
+
+    @abc.abstractmethod
+    def preview(self, **kwargs):
+        """
+        Abstract method that previews a machine learning model.
+        Must be implemented per machine learning framework, i.e, Tensorflow,
+        PyTorch etc.
+        """

--- a/tiledb/ml/models/pytorch.py
+++ b/tiledb/ml/models/pytorch.py
@@ -1,7 +1,5 @@
 """Functionality for saving and loading PytTorch models as TileDB arrays"""
 
-import sys
-import io
 import pickle
 import json
 import numpy as np
@@ -96,13 +94,7 @@ class PyTorchTileDB(TileDBModel):
         :param model: An torch.nn.Module object
         :return: A string representation of the models internal configuration.
         """
-        old_stdout = sys.stdout
-        new_stdout = io.StringIO()
-        sys.stdout = new_stdout
-        print(model)
-        output = new_stdout.getvalue()
-        sys.stdout = old_stdout
-        return output
+        return str(model)
 
     def _create_array(self, serialized_model_info: dict):
         """

--- a/tiledb/ml/models/pytorch.py
+++ b/tiledb/ml/models/pytorch.py
@@ -1,5 +1,7 @@
 """Functionality for saving and loading PytTorch models as TileDB arrays"""
 
+import sys
+import io
 import pickle
 import json
 import numpy as np
@@ -87,6 +89,20 @@ class PyTorchTileDB(TileDBModel):
                     model_array_results[attr_name].item(0)
                 )
         return out_dict
+
+    def preview(self, model: Module) -> str:
+        """
+        Creates a diagram representation of the model.
+        :param model: An torch.nn.Module object
+        :return: A string representation of the models internal configuration.
+        """
+        old_stdout = sys.stdout
+        new_stdout = io.StringIO()
+        sys.stdout = new_stdout
+        print(model)
+        output = new_stdout.getvalue()
+        sys.stdout = old_stdout
+        return output
 
     def _create_array(self, serialized_model_info: dict):
         """

--- a/tiledb/ml/models/sklearn.py
+++ b/tiledb/ml/models/sklearn.py
@@ -1,7 +1,5 @@
 """Functionality for saving and loading Sklearn models as TileDB arrays"""
 
-import sys
-import io
 import pickle
 import numpy as np
 import json
@@ -11,6 +9,7 @@ from typing import Optional, Tuple
 
 import sklearn
 from sklearn import set_config
+from sklearn import config_context
 from sklearn.base import BaseEstimator
 
 from .base import TileDBModel
@@ -69,14 +68,9 @@ class SklearnTileDB(TileDBModel):
         :return A string representation of the models internal configuration.
 
         """
-
-        old_stdout = sys.stdout
-        new_stdout = io.StringIO()
-        sys.stdout = new_stdout
         set_config(display=display)
-        print(model)
-        output = new_stdout.getvalue()
-        sys.stdout = old_stdout
+        output = str(model)
+        config_context(display="text")
         return output
 
     def _create_array(self):

--- a/tiledb/ml/models/sklearn.py
+++ b/tiledb/ml/models/sklearn.py
@@ -1,5 +1,7 @@
 """Functionality for saving and loading Sklearn models as TileDB arrays"""
 
+import sys
+import io
 import pickle
 import numpy as np
 import json
@@ -8,6 +10,7 @@ import tiledb
 from typing import Optional, Tuple
 
 import sklearn
+from sklearn import set_config
 from sklearn.base import BaseEstimator
 
 from .base import TileDBModel
@@ -56,6 +59,25 @@ class SklearnTileDB(TileDBModel):
         model_array_results = model_array[:]
         model = pickle.loads(model_array_results["model_params"].item(0))
         return model
+
+    def preview(self, model: BaseEstimator, display: str = "text") -> str:
+        """
+        Creates a diagram representation of the model.
+        :param model: An Sklearn Estimator object.
+        :param display: If ‘diagram’, estimators will be displayed as a diagram in an HTML format when shown in a jupyter notebook.
+        If ‘text’, estimators will be displayed as text. Default is ‘text’.
+        :return A string representation of the models internal configuration.
+
+        """
+
+        old_stdout = sys.stdout
+        new_stdout = io.StringIO()
+        sys.stdout = new_stdout
+        set_config(display=display)
+        print(model)
+        output = new_stdout.getvalue()
+        sys.stdout = old_stdout
+        return output
 
     def _create_array(self):
         """

--- a/tiledb/ml/models/tensorflow.py
+++ b/tiledb/ml/models/tensorflow.py
@@ -1,5 +1,6 @@
 """Functionality for saving and loading Tensorflow Keras models as TileDB arrays"""
 
+import io
 import logging
 import json
 import pickle
@@ -141,6 +142,18 @@ class TensorflowTileDB(TileDBModel):
                         "optimizer."
                     )
         return model
+
+    def preview(self, model: Model) -> str:
+        """
+        Creates a diagram representation of the model.
+        :param model:  Tensorflow model.
+        :return: A string representation of the models internal configuration.
+        """
+        s = io.StringIO()
+        model.summary(print_fn=lambda x: s.write(x + "\n"))
+        model_summary = s.getvalue()
+        s.close()
+        return model_summary
 
     def _create_array(self):
         """

--- a/tiledb/ml/models/tensorflow.py
+++ b/tiledb/ml/models/tensorflow.py
@@ -152,7 +152,6 @@ class TensorflowTileDB(TileDBModel):
         s = io.StringIO()
         model.summary(print_fn=lambda x: s.write(x + "\n"))
         model_summary = s.getvalue()
-        s.close()
         return model_summary
 
     def _create_array(self):


### PR DESCRIPTION
This PR refers to the story [ch7950]. We add support of a model function to provide internal model architecture representations of the model that will be used in model preview on Cloud. The representation is given back in `string` format.

Changed files & Additions:

```
tests/test_pytorch_models.py
tests/test_sklearn_models.py
tests/test_tensorflow_keras_models.py
tiledb/ml/models/base.py
tiledb/ml/models/pytorch.py
tiledb/ml/models/sklearn.py
tiledb/ml/models/tensorflow.py
```

`For our information:` There are alternatives for some of the frameworks in order to provide much detailed model summaries. However these alternatives apart from using `third-party` libraries, they also require the `input_sizes` of the models as they perform a forward-pass in order to extract the model summary. Specifically talking about `torchsummary` for the `pytorch` framework. Also except for `tf`, the APIs of the frameworks are designed to provide the output of models summaries in `stdout` and they do not return it as a `string`. They don't provide a function pointer so someone can handle the output and thus our implementation becomes a little "hacky" by fishing the outputs from `stdout` and putting it in `str`. Glad to listen to alternatives if any.