### PR TITLE
[Enhancement] Add prefix to ML Model metadata

### DIFF
--- a/tests/test_pytorch_models.py
+++ b/tests/test_pytorch_models.py
@@ -152,13 +152,17 @@ class TestPyTorchModel:
         tiledb_obj = PyTorchTileDBModel(uri=tiledb_array)
         tiledb_obj.save(model_info={"state_dict": saved_net.state_dict()})
 
-        assert tiledb_obj._file_properties["ML_FRAMEWORK"] == "PYTORCH"
-        assert tiledb_obj._file_properties["STAGE"] == "STAGING"
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK"] == "PYTORCH"
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_STAGE"] == "STAGING"
         assert (
-            tiledb_obj._file_properties["PYTHON_VERSION"] == platform.python_version()
+            tiledb_obj._file_properties["TILEDB_ML_MODEL_PYTHON_VERSION"]
+            == platform.python_version()
         )
-        assert tiledb_obj._file_properties["ML_FRAMEWORK_VERSION"] == torch.__version__
-        assert tiledb_obj._file_properties["PREVIEW"] == ""
+        assert (
+            tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK_VERSION"]
+            == torch.__version__
+        )
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_PREVIEW"] == ""
 
     def test_file_properties_in_tiledb_cloud_case(self, tmpdir, net, optimizer, mocker):
         saved_net = net()
@@ -172,13 +176,17 @@ class TestPyTorchModel:
         tiledb_obj = PyTorchTileDBModel(uri=tiledb_array, namespace="test_namespace")
         tiledb_obj.save(model_info={"state_dict": saved_net.state_dict()})
 
-        assert tiledb_obj._file_properties["ML_FRAMEWORK"] == "PYTORCH"
-        assert tiledb_obj._file_properties["STAGE"] == "STAGING"
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK"] == "PYTORCH"
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_STAGE"] == "STAGING"
         assert (
-            tiledb_obj._file_properties["PYTHON_VERSION"] == platform.python_version()
+            tiledb_obj._file_properties["TILEDB_ML_MODEL_PYTHON_VERSION"]
+            == platform.python_version()
         )
-        assert tiledb_obj._file_properties["ML_FRAMEWORK_VERSION"] == torch.__version__
-        assert tiledb_obj._file_properties["PREVIEW"] == ""
+        assert (
+            tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK_VERSION"]
+            == torch.__version__
+        )
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_PREVIEW"] == ""
 
     def test_exception_raise_file_property_in_meta_error(self, tmpdir, net, optimizer):
         saved_net = net()
@@ -187,5 +195,5 @@ class TestPyTorchModel:
         with pytest.raises(ValueError):
             tiledb_obj.save(
                 model_info={"state_dict": saved_net.state_dict()},
-                meta={"ML_FRAMEWORK": "ML_FRAMEWORK"},
+                meta={"TILEDB_ML_MODEL_ML_FRAMEWORK": "TILEDB_ML_MODEL_ML_FRAMEWORK"},
             )

--- a/tests/test_sklearn_models.py
+++ b/tests/test_sklearn_models.py
@@ -53,15 +53,17 @@ class TestSklearnModel:
         tiledb_obj = SklearnTileDBModel(uri=tiledb_array)
         tiledb_obj.save(model=model)
 
-        assert tiledb_obj._file_properties["ML_FRAMEWORK"] == "SKLEARN"
-        assert tiledb_obj._file_properties["STAGE"] == "STAGING"
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK"] == "SKLEARN"
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_STAGE"] == "STAGING"
         assert (
-            tiledb_obj._file_properties["PYTHON_VERSION"] == platform.python_version()
+            tiledb_obj._file_properties["TILEDB_ML_MODEL_PYTHON_VERSION"]
+            == platform.python_version()
         )
         assert (
-            tiledb_obj._file_properties["ML_FRAMEWORK_VERSION"] == sklearn.__version__
+            tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK_VERSION"]
+            == sklearn.__version__
         )
-        assert tiledb_obj._file_properties["PREVIEW"] == ""
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_PREVIEW"] == ""
 
     def test_file_properties_in_tiledb_cloud_case(self, tmpdir, net, mocker):
         model = net()
@@ -75,19 +77,24 @@ class TestSklearnModel:
         tiledb_obj = SklearnTileDBModel(uri=tiledb_array, namespace="test_namespace")
         tiledb_obj.save(model=model)
 
-        assert tiledb_obj._file_properties["ML_FRAMEWORK"] == "SKLEARN"
-        assert tiledb_obj._file_properties["STAGE"] == "STAGING"
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK"] == "SKLEARN"
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_STAGE"] == "STAGING"
         assert (
-            tiledb_obj._file_properties["PYTHON_VERSION"] == platform.python_version()
+            tiledb_obj._file_properties["TILEDB_ML_MODEL_PYTHON_VERSION"]
+            == platform.python_version()
         )
         assert (
-            tiledb_obj._file_properties["ML_FRAMEWORK_VERSION"] == sklearn.__version__
+            tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK_VERSION"]
+            == sklearn.__version__
         )
-        assert tiledb_obj._file_properties["PREVIEW"] == ""
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_PREVIEW"] == ""
 
     def test_exception_raise_file_property_in_meta_error(self, tmpdir, net):
         model = net()
         tiledb_array = os.path.join(tmpdir, "model_array")
         tiledb_obj = SklearnTileDBModel(uri=tiledb_array)
         with pytest.raises(ValueError):
-            tiledb_obj.save(model=model, meta={"ML_FRAMEWORK": "ML_FRAMEWORK"})
+            tiledb_obj.save(
+                model=model,
+                meta={"TILEDB_ML_MODEL_ML_FRAMEWORK": "TILEDB_ML_MODEL_ML_FRAMEWORK"},
+            )

--- a/tests/test_tensorflow_keras_models.py
+++ b/tests/test_tensorflow_keras_models.py
@@ -410,11 +410,17 @@ def test_file_properties(tmpdir):
     tiledb_obj = TensorflowKerasTileDBModel(uri=tiledb_array)
     tiledb_obj.save(model=model)
 
-    assert tiledb_obj._file_properties["ML_FRAMEWORK"] == "TENSORFLOW KERAS"
-    assert tiledb_obj._file_properties["STAGE"] == "STAGING"
-    assert tiledb_obj._file_properties["PYTHON_VERSION"] == platform.python_version()
-    assert tiledb_obj._file_properties["ML_FRAMEWORK_VERSION"] == tf.__version__
-    assert tiledb_obj._file_properties["PREVIEW"] == ""
+    assert tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK"] == "TENSORFLOW KERAS"
+    assert tiledb_obj._file_properties["TILEDB_ML_MODEL_STAGE"] == "STAGING"
+    assert (
+        tiledb_obj._file_properties["TILEDB_ML_MODEL_PYTHON_VERSION"]
+        == platform.python_version()
+    )
+    assert (
+        tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK_VERSION"]
+        == tf.__version__
+    )
+    assert tiledb_obj._file_properties["TILEDB_ML_MODEL_PREVIEW"] == ""
 
 
 def test_file_properties_in_tiledb_cloud_case(tmpdir, mocker):
@@ -433,11 +439,17 @@ def test_file_properties_in_tiledb_cloud_case(tmpdir, mocker):
     )
     tiledb_obj.save(model=model)
 
-    assert tiledb_obj._file_properties["ML_FRAMEWORK"] == "TENSORFLOW KERAS"
-    assert tiledb_obj._file_properties["STAGE"] == "STAGING"
-    assert tiledb_obj._file_properties["PYTHON_VERSION"] == platform.python_version()
-    assert tiledb_obj._file_properties["ML_FRAMEWORK_VERSION"] == tf.__version__
-    assert tiledb_obj._file_properties["PREVIEW"] == ""
+    assert tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK"] == "TENSORFLOW KERAS"
+    assert tiledb_obj._file_properties["TILEDB_ML_MODEL_STAGE"] == "STAGING"
+    assert (
+        tiledb_obj._file_properties["TILEDB_ML_MODEL_PYTHON_VERSION"]
+        == platform.python_version()
+    )
+    assert (
+        tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK_VERSION"]
+        == tf.__version__
+    )
+    assert tiledb_obj._file_properties["TILEDB_ML_MODEL_PREVIEW"] == ""
 
 
 def test_exception_raise_file_property_in_meta_error(tmpdir):
@@ -446,4 +458,7 @@ def test_exception_raise_file_property_in_meta_error(tmpdir):
     tiledb_array = os.path.join(tmpdir, "model_array")
     tiledb_obj = TensorflowKerasTileDBModel(uri=tiledb_array)
     with pytest.raises(ValueError):
-        tiledb_obj.save(model=model, meta={"ML_FRAMEWORK": "ML_FRAMEWORK"})
+        tiledb_obj.save(
+            model=model,
+            meta={"TILEDB_ML_MODEL_ML_FRAMEWORK": "TILEDB_ML_MODEL_ML_FRAMEWORK"},
+        )

--- a/tiledb/ml/models/base.py
+++ b/tiledb/ml/models/base.py
@@ -20,11 +20,11 @@ class ModelFileProperties(Enum):
     Enum Class that contains all model array file properties.
     """
 
-    ML_FRAMEWORK = "ML_FRAMEWORK"
-    ML_FRAMEWORK_VERSION = "ML_FRAMEWORK_VERSION"
-    STAGE = "STAGE"
-    PYTHON_VERSION = "PYTHON_VERSION"
-    PREVIEW = "PREVIEW"
+    TILEDB_ML_MODEL_ML_FRAMEWORK = "TILEDB_ML_MODEL_ML_FRAMEWORK"
+    TILEDB_ML_MODEL_ML_FRAMEWORK_VERSION = "TILEDB_ML_MODEL_ML_FRAMEWORK_VERSION"
+    TILEDB_ML_MODEL_STAGE = "TILEDB_ML_MODEL_STAGE"
+    TILEDB_ML_MODEL_PYTHON_VERSION = "TILEDB_ML_MODEL_PYTHON_VERSION"
+    TILEDB_ML_MODEL_PREVIEW = "TILEDB_ML_MODEL_PREVIEW"
 
 
 class TileDBModel(abc.ABC):
@@ -88,11 +88,11 @@ class TileDBModel(abc.ABC):
         Method that sets model array's file properties.
         """
         self._file_properties = {
-            ModelFileProperties.ML_FRAMEWORK.value: self.Framework,
-            ModelFileProperties.ML_FRAMEWORK_VERSION.value: self.FrameworkVersion,
-            ModelFileProperties.STAGE.value: "STAGING",
-            ModelFileProperties.PYTHON_VERSION.value: platform.python_version(),
-            ModelFileProperties.PREVIEW.value: self.preview(),
+            ModelFileProperties.TILEDB_ML_MODEL_ML_FRAMEWORK.value: self.Framework,
+            ModelFileProperties.TILEDB_ML_MODEL_ML_FRAMEWORK_VERSION.value: self.FrameworkVersion,
+            ModelFileProperties.TILEDB_ML_MODEL_STAGE.value: "STAGING",
+            ModelFileProperties.TILEDB_ML_MODEL_PYTHON_VERSION.value: platform.python_version(),
+            ModelFileProperties.TILEDB_ML_MODEL_PREVIEW.value: self.preview(),
         }
 
     def update_model_metadata(self, array: tiledb.Array, meta: Optional[dict] = {}):


### PR DESCRIPTION
This PR concerns the request [ch8568]. Certain metadata will be treated differently in UI, outside the metadata page. Those metadata will be only displayed in overview page of array. In order to make it easier to handle in frontend we add a prefix for those metadata:

Changed files:
```
examples/models/tensorflow_keras_tiledb_models_example.ipynb
tests/test_pytorch_models.py
tests/test_sklearn_models.py
tests/test_tensorflow_keras_models.py
tiledb/ml/models/base.py
```