### PR TITLE
Change Model API

### DIFF
--- a/examples/cloud/pytorch_tiledb_cloud_ml_model_array.ipynb
+++ b/examples/cloud/pytorch_tiledb_cloud_ml_model_array.ipynb
@@ -259,11 +259,8 @@
     "tiledb_cloud_model_uri = tiledb_model.uri\n",
     "\n",
     "print('Saving model on S3 and registering on TileDB-Cloud...')\n",
-    "tiledb_model.save(model_info={\n",
-    "    'model_state_dict': model.state_dict(),\n",
-    "    'optimizer_state_dict': optimizer.state_dict(),\n",
-    "    }, meta={'epochs': epochs,\n",
-    "            'train_loss': train_losses})\n"
+    "tiledb_model.save(meta={'epochs': epochs,\n",
+    "                        'train_loss': train_losses})\n"
    ]
   },
   {
@@ -279,6 +276,7 @@
    "execution_count": null,
    "metadata": {
     "pycharm": {
+     "is_executing": true,
      "name": "#%%\n"
     }
    },
@@ -318,6 +316,13 @@
     "# Deregister model\n",
     "tiledb.cloud.deregister_array(tiledb_cloud_model_uri)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/cloud/sklearn_tiledb_cloud_ml_model_array.ipynb
+++ b/examples/cloud/sklearn_tiledb_cloud_ml_model_array.ipynb
@@ -161,9 +161,7 @@
     "tiledb_cloud_model_uri = tiledb_model.uri\n",
     "\n",
     "print('Saving model on S3 and registering on TileDB-Cloud...')\n",
-    "tiledb_model.save(\n",
-    "    model=model, meta={\"Sparsity_with_L1_penalty\": sparsity, \"score\": score}\n",
-    ")\n"
+    "tiledb_model.save(meta={\"Sparsity_with_L1_penalty\": sparsity, \"score\": score})\n"
    ]
   },
   {

--- a/examples/cloud/tensorflow_tiledb_cloud_ml_model_array.ipynb
+++ b/examples/cloud/tensorflow_tiledb_cloud_ml_model_array.ipynb
@@ -145,7 +145,7 @@
     "tiledb_cloud_model_uri = tiledb_model.uri\n",
     "\n",
     "print('Saving model on S3 and registering on TileDB-Cloud...')\n",
-    "tiledb_model.save(model=model)\n"
+    "tiledb_model.save()\n"
    ]
   },
   {

--- a/examples/models/pytorch_tiledb_models_example.ipynb
+++ b/examples/models/pytorch_tiledb_models_example.ipynb
@@ -236,12 +236,9 @@
    },
    "outputs": [],
    "source": [
-    "tiledb_model_1 = PyTorchTileDBModel(uri='tiledb-pytorch-mnist-1')\n",
+    "tiledb_model_1 = PyTorchTileDBModel(uri='tiledb-pytorch-mnist-1', model=network, optimizer=optimizer)\n",
     "\n",
-    "tiledb_model_1.save(update=False, model_info={\n",
-    "    'model_state_dict': network.state_dict(),\n",
-    "    'optimizer_state_dict': optimizer.state_dict(),\n",
-    "    },\n",
+    "tiledb_model_1.save(update=False,\n",
     "                    meta={'epochs': epochs,\n",
     "                          'train_loss': train_losses})"
    ]
@@ -413,10 +410,8 @@
     "  train(epoch)\n",
     "\n",
     "# and update\n",
-    "tiledb_model_1.save(update=True, model_info={\n",
-    "    'model_state_dict': network.state_dict(),\n",
-    "    'optimizer_state_dict': optimizer.state_dict(),\n",
-    "    },\n",
+    "tiledb_model_1 = PyTorchTileDBModel(uri='tiledb-pytorch-mnist-1', model=network, optimizer=optimizer)\n",
+    "tiledb_model_1.save(update=True, \n",
     "                    meta={'epochs': epochs,\n",
     "                          'train_loss': train_losses})\n",
     "\n",
@@ -521,12 +516,9 @@
     "for epoch in range(1, epochs + 1):\n",
     "    train(epoch)\n",
     "\n",
-    "tiledb_model_2 = PyTorchTileDBModel(uri='tiledb-pytorch-mnist-2')\n",
+    "tiledb_model_2 = PyTorchTileDBModel(uri='tiledb-pytorch-mnist-2', model=network, optimizer=optimizer)\n",
     "\n",
-    "tiledb_model_2.save(update=False, model_info={\n",
-    "    'model_state_dict': network.state_dict(),\n",
-    "    'optimizer_state_dict': optimizer.state_dict(),\n",
-    "    },\n",
+    "tiledb_model_2.save(update=False, \n",
     "                    meta={'epochs': epochs,\n",
     "                          'train_loss': train_losses})"
    ]
@@ -574,6 +566,13 @@
    "source": [
     "tiledb.ls('MNIST_Group', lambda obj_path, obj_type: print(obj_path, obj_type))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -592,7 +591,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/examples/models/pytorch_tiledb_models_example.ipynb
+++ b/examples/models/pytorch_tiledb_models_example.ipynb
@@ -218,10 +218,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now save the trained model as a TileDB array. In case we want to train  the model further in a later time, we can save\n",
-    "optimizer's state_dict in our TileDB array. In case we will use our model only for inference, we don't have to save optimizer's\n",
-    "state_dict and we only keep model's state_dict. We first declare a PytTorchTileDB object (with the corresponding uri) and then\n",
-    "save the model as a TileDB array. Finally, we can save any kind of meta data (in any structure, i.e., list, tuple or dictionary)\n",
+    "We can now save the trained model as a TileDB array. In case we want to train  the model further in a later time, we can also save\n",
+    "the optimizer in our TileDB array. In case we will use our model only for inference, we don't have to save the optimizer and we\n",
+    "only keep the model. We first declare a PytTorchTileDB object and initialize it with the corresponding TileDB uri, model and optimizer,\n",
+    "and then save the model as a TileDB array. Finally, we can save any kind of metadata (in any structure, i.e., list, tuple or dictionary)\n",
     "by passing a dictionary to the meta attribute."
    ]
   },
@@ -314,7 +314,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the case of PyTorch models, as mentioned above, we save model's state_dict and optimizer's state_dict,\n",
+    "For the case of PyTorch models, internally, we save model's state_dict and optimizer's state_dict,\n",
     "as [variable sized attributes)](https://docs.tiledb.com/main/solutions/tiledb-embedded/api-usage/writing-arrays/var-length-attributes)\n",
     "(pickled), i.e., we can open the TileDB and get only the state_dict of the model or optimizer,\n",
     "without bringing the whole model in memory. For example, we can load model's and optimizer's state_dict\n",

--- a/examples/models/sklearn_tiledb_models_example.ipynb
+++ b/examples/models/sklearn_tiledb_models_example.ipynb
@@ -132,7 +132,7 @@
     "TileDB array in terms of files on disk please take a look [here](https://docs.tiledb.com/main/basic-concepts/data-format).\n",
     "At the moment (will change in the future) we use pickle, which is one of the [most common scenarios for sklearn models](https://scikit-learn.org/stable/modules/model_persistence.html),\n",
     "to serialize the whole model and save it as a [variable sized attribute](https://docs.tiledb.com/main/solutions/tiledb-embedded/api-usage/writing-arrays/var-length-attributes)\n",
-    "in a TileDB array.  We first declare a SklearnTileDBModel object (with the corresponding uri) and then save the model as a TileDB array.\n",
+    "in a TileDB array.  We first declare a SklearnTileDBModel object (with the corresponding uri and model attributes) and then save the model as a TileDB array.\n",
     "Finally, we can save any kind of metadata (in any structure, i.e., list, tuple or dictionary) by passing a dictionary to the meta attribute."
    ]
   },
@@ -156,7 +156,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The above step will create a TileDB array in your working directory. Let's open our TileDB array model and check metadata. Metadata that are of type list, dict or tuple have been JSON\n",
+    "The above step will create a TileDB array in your working directory. Let's open our TileDB array model and check metadata.\n",
+    "Metadata that are of type list, dict or tuple have been JSON\n",
     "serialized while saving, i.e., we need json.loads to deserialize them."
    ]
   },

--- a/examples/models/sklearn_tiledb_models_example.ipynb
+++ b/examples/models/sklearn_tiledb_models_example.ipynb
@@ -146,10 +146,9 @@
    },
    "outputs": [],
    "source": [
-    "tiledb_model_1 = SklearnTileDBModel(uri='tiledb-sklearn-mnist-1')\n",
+    "tiledb_model_1 = SklearnTileDBModel(uri='tiledb-sklearn-mnist-1', model=clf)\n",
     "\n",
-    "tiledb_model_1.save(model=clf,\n",
-    "                    meta={'Sparsity_with_L1_penalty': sparsity,\n",
+    "tiledb_model_1.save(meta={'Sparsity_with_L1_penalty': sparsity,\n",
     "                          'score': score})"
    ]
   },
@@ -263,8 +262,9 @@
     "print(\"Sparsity with L1 penalty: %.2f%%\" % sparsity)\n",
     "print(\"Test score with L1 penalty: %.4f\" % score)\n",
     "\n",
-    "tiledb_model_1.save(model=loaded_clf,\n",
-    "                    update=True,\n",
+    "\n",
+    "tiledb_model_1 = SklearnTileDBModel(uri='tiledb-sklearn-mnist-1', model=loaded_clf)\n",
+    "tiledb_model_1.save(update=True,\n",
     "                    meta={'Sparsity_with_L1_penalty': sparsity,\n",
     "                          'score': score})\n",
     "\n",
@@ -335,11 +335,10 @@
     "print(\"Test score: %.4f\" % score)\n",
     "\n",
     "# Declare a SklearnTileDBModel object\n",
-    "tiledb_model_2 = SklearnTileDBModel(uri='tiledb-sklearn-mnist-2')\n",
+    "tiledb_model_2 = SklearnTileDBModel(uri='tiledb-sklearn-mnist-2', model=clf)\n",
     "\n",
     "# Save model as a TileDB array\n",
-    "tiledb_model_2.save(model=clf,\n",
-    "                    meta={'score': score})"
+    "tiledb_model_2.save(meta={'score': score})"
    ]
   },
   {
@@ -384,6 +383,13 @@
    "source": [
     "tiledb.ls('MNIST_Group', lambda obj_path, obj_type: print(obj_path, obj_type))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -402,7 +408,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/examples/models/tensorflow_keras_tiledb_models_example.ipynb
+++ b/examples/models/tensorflow_keras_tiledb_models_example.ipynb
@@ -129,10 +129,9 @@
    },
    "outputs": [],
    "source": [
-    "tiledb_model_1 = TensorflowKerasTileDBModel(uri='tiledb-keras-mnist-sequential-1')\n",
+    "tiledb_model_1 = TensorflowKerasTileDBModel(uri='tiledb-keras-mnist-sequential-1', model=model)\n",
     "\n",
-    "tiledb_model_1.save(model=model,\n",
-    "                    include_optimizer=True,\n",
+    "tiledb_model_1.save(include_optimizer=True,\n",
     "                    update=False)"
    ]
   },
@@ -227,14 +226,12 @@
     "model = create_model()\n",
     "model.fit(x_train[:30000], y_train[:30000], epochs=5)\n",
     "\n",
-    "tiledb_model_2 = TensorflowKerasTileDBModel(uri='tiledb-keras-mnist-sequential-2')\n",
+    "tiledb_model_2 = TensorflowKerasTileDBModel(uri='tiledb-keras-mnist-sequential-2', model=model)\n",
     "\n",
-    "tiledb_model_2.save(model=model,\n",
-    "                    include_optimizer=True,\n",
+    "tiledb_model_2.save(include_optimizer=True,\n",
     "                    update=False,\n",
     "                    meta={\"accuracy\": model.history.history['accuracy'],\n",
     "                          \"loss\": model.history.history['loss'],\n",
-    "                          \"version\": '0.0.1',\n",
     "                          \"status\": 'experimental'})\n",
     "\n",
     "# Check array directory\n",
@@ -368,8 +365,8 @@
     "loaded_model_1.fit(x_train[30000:], y_train[30000:], epochs=5)\n",
     "\n",
     "# and update\n",
-    "tiledb_model_1.save(model=loaded_model_1,\n",
-    "                    include_optimizer=True,\n",
+    "tiledb_model_1 = TensorflowKerasTileDBModel(uri='tiledb-keras-mnist-sequential-1', model=loaded_model_1)\n",
+    "tiledb_model_1.save(include_optimizer=True,\n",
     "                    update=True,\n",
     "                    meta={\"accuracy\": model.history.history['accuracy'],\n",
     "                          \"loss\": model.history.history['loss'],\n",
@@ -472,15 +469,13 @@
     "model = create_deeper_model()\n",
     "model.fit(x_train, y_train, epochs=5)\n",
     "\n",
-    "tiledb_deeper_model = TensorflowKerasTileDBModel(uri='tiledb-keras-mnist-sequential-deeper')\n",
+    "tiledb_deeper_model = TensorflowKerasTileDBModel(uri='tiledb-keras-mnist-sequential-deeper', model=model)\n",
     "\n",
-    "tiledb_deeper_model.save(model=model,\n",
-    "                         include_optimizer=True,\n",
+    "tiledb_deeper_model.save(include_optimizer=True,\n",
     "                         update=False,\n",
-    "                        meta={\"accuracy\": model.history.history['accuracy'],\n",
-    "                              \"loss\": model.history.history['loss'],\n",
-    "                              \"version\": '0.0.1',\n",
-    "                              \"status\": 'experimental'})\n",
+    "                         meta={\"accuracy\": model.history.history['accuracy'],\n",
+    "                               \"loss\": model.history.history['loss'],\n",
+    "                               \"status\": 'experimental'})\n",
     "\n",
     "# Check array directory\n",
     "print()\n",
@@ -539,6 +534,13 @@
    "source": [
     "tiledb.ls('MNIST_Group', lambda obj_path, obj_type: print(obj_path, obj_type))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -557,7 +559,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/examples/models/tensorflow_keras_tiledb_models_example.ipynb
+++ b/examples/models/tensorflow_keras_tiledb_models_example.ipynb
@@ -115,8 +115,8 @@
    "source": [
     "We can now save the trained model as a TileDB array. In case we want to train  the model further in a later time, we can save\n",
     "optimizer's information in our TileDB array. In case we will use our model only for inference, we don't have to save optimizer's\n",
-    "information and we only keep model's weights. We first declare a TileDB-Keras model object (with the corresponding uri) and then\n",
-    "save the model as a TileDB array."
+    "information and we only keep model's weights. We first declare a TileDB-Keras model object (with the corresponding uri and model attributes)\n",
+    "and then save the model as a TileDB array."
    ]
   },
   {
@@ -344,8 +344,8 @@
     "What is really nice with saving models as TileDB array, is native versioning based on fragments as described\n",
     "[here](https://docs.tiledb.com/main/basic-concepts/data-format#immutable-fragments). We can load a model, retrain it\n",
     "with new data and update the already existing TileDB model array with new model parameters and metadata. All information, old\n",
-    "and new will be there and accessible. This is extremely useful when you retrain with new data or trying different architectures for the same\n",
-    "problem, and you want to keep track of all your experiments without having to store different model instances. In our case,\n",
+    "and new will be there and accessible. This is extremely useful when you retrain with new data or trying different architectures\n",
+    "for the same problem, and you want to keep track of all your experiments without having to store different model instances. In our case,\n",
     "let's continue training model_1 with the rest of our dataset and for 5 more epochs. After training is done, you will\n",
     "notice the extra directories and files (fragments) added to tiledb-keras-mnist-sequential-1 TileDB array directory,\n",
     "which keep all versions of the model."

--- a/tests/test_sklearn_models.py
+++ b/tests/test_sklearn_models.py
@@ -26,8 +26,8 @@ class TestSklearnModel:
     def test_save_load(self, tmpdir, net):
         tiledb_array = os.path.join(tmpdir, "test_array")
         model = net()
-        tiledb_sklearn_obj = SklearnTileDBModel(uri=tiledb_array)
-        tiledb_sklearn_obj.save(model=model)
+        tiledb_sklearn_obj = SklearnTileDBModel(uri=tiledb_array, model=model)
+        tiledb_sklearn_obj.save()
         loaded_model = tiledb_sklearn_obj.load()
         assert all(
             [
@@ -43,15 +43,11 @@ class TestSklearnModel:
         tiledb_sklearn_obj = SklearnTileDBModel(uri=tiledb_array, model=model)
         assert type(tiledb_sklearn_obj.preview()) == str
 
-        # Without model as argumet
-        tiledb_sklearn_obj = SklearnTileDBModel(uri=tiledb_array)
-        assert type(tiledb_sklearn_obj.preview()) == str
-
     def test_file_properties(self, tmpdir, net):
         model = net()
         tiledb_array = os.path.join(tmpdir, "model_array")
-        tiledb_obj = SklearnTileDBModel(uri=tiledb_array)
-        tiledb_obj.save(model=model)
+        tiledb_obj = SklearnTileDBModel(uri=tiledb_array, model=model)
+        tiledb_obj.save()
 
         assert tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK"] == "SKLEARN"
         assert tiledb_obj._file_properties["TILEDB_ML_MODEL_STAGE"] == "STAGING"
@@ -63,7 +59,7 @@ class TestSklearnModel:
             tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK_VERSION"]
             == sklearn.__version__
         )
-        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_PREVIEW"] == ""
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_PREVIEW"] == str(model)
 
     def test_file_properties_in_tiledb_cloud_case(self, tmpdir, net, mocker):
         model = net()
@@ -74,8 +70,10 @@ class TestSklearnModel:
         )
         mocker.patch("tiledb.ml._cloud_utils.update_file_properties")
 
-        tiledb_obj = SklearnTileDBModel(uri=tiledb_array, namespace="test_namespace")
-        tiledb_obj.save(model=model)
+        tiledb_obj = SklearnTileDBModel(
+            uri=tiledb_array, namespace="test_namespace", model=model
+        )
+        tiledb_obj.save()
 
         assert tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK"] == "SKLEARN"
         assert tiledb_obj._file_properties["TILEDB_ML_MODEL_STAGE"] == "STAGING"
@@ -87,14 +85,13 @@ class TestSklearnModel:
             tiledb_obj._file_properties["TILEDB_ML_MODEL_ML_FRAMEWORK_VERSION"]
             == sklearn.__version__
         )
-        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_PREVIEW"] == ""
+        assert tiledb_obj._file_properties["TILEDB_ML_MODEL_PREVIEW"] == str(model)
 
     def test_exception_raise_file_property_in_meta_error(self, tmpdir, net):
         model = net()
         tiledb_array = os.path.join(tmpdir, "model_array")
-        tiledb_obj = SklearnTileDBModel(uri=tiledb_array)
+        tiledb_obj = SklearnTileDBModel(uri=tiledb_array, model=model)
         with pytest.raises(ValueError):
             tiledb_obj.save(
-                model=model,
                 meta={"TILEDB_ML_MODEL_ML_FRAMEWORK": "TILEDB_ML_MODEL_ML_FRAMEWORK"},
             )

--- a/tiledb/ml/models/base.py
+++ b/tiledb/ml/models/base.py
@@ -41,7 +41,7 @@ class TileDBModel(abc.ABC):
         uri: str,
         namespace: str = None,
         ctx: tiledb.Ctx = None,
-        model: Optional[Union[Module, Model, BaseEstimator]] = None,
+        model: Union[Module, Model, BaseEstimator] = None,
     ):
         """
         Base class for saving machine learning models as TileDB arrays
@@ -57,8 +57,15 @@ class TileDBModel(abc.ABC):
         self.namespace = namespace
         self.ctx = ctx
         self.model = model
-        self._file_properties = {}
         self.uri = self.get_cloud_uri(uri) if self.namespace else uri
+
+        self._file_properties = {
+            ModelFileProperties.TILEDB_ML_MODEL_ML_FRAMEWORK.value: self.Framework,
+            ModelFileProperties.TILEDB_ML_MODEL_ML_FRAMEWORK_VERSION.value: self.FrameworkVersion,
+            ModelFileProperties.TILEDB_ML_MODEL_STAGE.value: "STAGING",
+            ModelFileProperties.TILEDB_ML_MODEL_PYTHON_VERSION.value: platform.python_version(),
+            ModelFileProperties.TILEDB_ML_MODEL_PREVIEW.value: self.preview(),
+        }
 
     @abc.abstractmethod
     def save(self, **kwargs):
@@ -82,18 +89,6 @@ class TileDBModel(abc.ABC):
         Must be implemented per machine learning framework, i.e, Tensorflow,
         PyTorch etc.
         """
-
-    def set_file_properties(self):
-        """
-        Method that sets model array's file properties.
-        """
-        self._file_properties = {
-            ModelFileProperties.TILEDB_ML_MODEL_ML_FRAMEWORK.value: self.Framework,
-            ModelFileProperties.TILEDB_ML_MODEL_ML_FRAMEWORK_VERSION.value: self.FrameworkVersion,
-            ModelFileProperties.TILEDB_ML_MODEL_STAGE.value: "STAGING",
-            ModelFileProperties.TILEDB_ML_MODEL_PYTHON_VERSION.value: platform.python_version(),
-            ModelFileProperties.TILEDB_ML_MODEL_PREVIEW.value: self.preview(),
-        }
 
     def update_model_metadata(self, array: tiledb.Array, meta: Optional[dict] = {}):
         """

--- a/tiledb/ml/models/pytorch.py
+++ b/tiledb/ml/models/pytorch.py
@@ -22,27 +22,62 @@ class PyTorchTileDBModel(TileDBModel):
     Framework = "PYTORCH"
     FrameworkVersion = torch.__version__
 
-    def save(self, model_info: dict, update: bool = False, meta: Optional[dict] = {}):
+    def __init__(
+        self,
+        uri: str,
+        namespace: str = None,
+        ctx: tiledb.Ctx = None,
+        model: Module = None,
+        optimizer: Optional[Optimizer] = None,
+    ):
+        super().__init__(uri, namespace, ctx, model)
+        self.optimizer = optimizer
+
+    def save(
+        self,
+        model_info: Optional[dict] = {},
+        update: bool = False,
+        meta: Optional[dict] = {},
+    ):
         """
         Saves a PyTorch model as a TileDB array.
-        :param model_info: Python dictionary. Contains all model info like,
-        model.state_dict(), optimizer.state_dict(), loss, etc.
+        :param model_info: Optional[dict]. Contains model info like loss, epoch etc, that could be needed
+        to save a model's general checkpoint for inference and/or resuming training.
         :param update: Whether we should update any existing TileDB array
         model at the target location.
         :param meta: Dict. Extra metadata to save in a TileDB array.
         """
         # Serialize model information
-        serialized_model_info = {
-            key: pickle.dumps(value, protocol=4) for key, value in model_info.items()
+        serialized_model_info = (
+            {key: pickle.dumps(value, protocol=4) for key, value in model_info.items()}
+            if model_info
+            else {}
+        )
+
+        serialized_model_dict = {
+            "model_state_dict": pickle.dumps(self.model.state_dict(), protocol=4)
+        }
+
+        serialized_optimizer_dict = {
+            "optimizer_state_dict": pickle.dumps(
+                self.optimizer.state_dict(), protocol=4
+            )
+            if self.optimizer
+            else {}
         }
 
         # Create TileDB model array
         if not update:
             self._create_array(serialized_model_info)
 
-        self.set_file_properties()
-
-        self._write_array(serialized_model_info=serialized_model_info, meta=meta)
+        self._write_array(
+            serialized_model={
+                **serialized_model_dict,
+                **serialized_optimizer_dict,
+                **serialized_model_info,
+            },
+            meta=meta,
+        )
 
     def load(
         self,
@@ -105,16 +140,41 @@ class PyTorchTileDBModel(TileDBModel):
 
         attrs = []
 
-        for key in serialized_model_info:
+        # Keep model's state dictionary
+        attrs.append(
+            tiledb.Attr(
+                name="model_state_dict",
+                dtype="S1",
+                var=True,
+                filters=tiledb.FilterList([tiledb.ZstdFilter()]),
+                ctx=self.ctx,
+            ),
+        )
+
+        # If optimizer is provided we also keep optimizer's state dictionary
+        if self.optimizer:
             attrs.append(
                 tiledb.Attr(
-                    name=key,
+                    name="optimizer_state_dict",
                     dtype="S1",
                     var=True,
                     filters=tiledb.FilterList([tiledb.ZstdFilter()]),
                     ctx=self.ctx,
                 ),
             )
+
+        # Add extra attributes in case model information is provided by the user
+        if serialized_model_info:
+            for key in serialized_model_info:
+                attrs.append(
+                    tiledb.Attr(
+                        name=key,
+                        dtype="S1",
+                        var=True,
+                        filters=tiledb.FilterList([tiledb.ZstdFilter()]),
+                        ctx=self.ctx,
+                    ),
+                )
 
         schema = tiledb.ArraySchema(
             domain=dom,
@@ -131,16 +191,17 @@ class PyTorchTileDBModel(TileDBModel):
 
             update_file_properties(self.uri, self._file_properties)
 
-    def _write_array(self, serialized_model_info: dict, meta: Optional[dict]):
+    def _write_array(self, serialized_model: dict, meta: Optional[dict]):
         """
         Writes a PyTorch model to a TileDB array.
-        :param serialized_model_info: Dict. A dictionary with serialized (pickled) information of a PyTorch model.
+        :param serialized_model: Dict. A dictionary with serialized (pickled) information (model state dictionary,
+        optimizer state dictionary, extra model information) of a PyTorch model.
         :param meta: Optional Dict. Extra metadata the user will save as model array's metadata.
         """
         with tiledb.open(self.uri, "w", ctx=self.ctx) as tf_model_tiledb:
             # Insertion in TileDB array
             insertion_dict = {
-                key: np.array([value]) for key, value in serialized_model_info.items()
+                key: np.array([value]) for key, value in serialized_model.items()
             }
 
             tf_model_tiledb[:] = insertion_dict

--- a/tiledb/ml/models/sklearn.py
+++ b/tiledb/ml/models/sklearn.py
@@ -22,24 +22,19 @@ class SklearnTileDBModel(TileDBModel):
     Framework = "SKLEARN"
     FrameworkVersion = sklearn.__version__
 
-    def save(
-        self, model: BaseEstimator, update: bool = False, meta: Optional[dict] = {}
-    ):
+    def save(self, update: bool = False, meta: Optional[dict] = {}):
         """
         Saves a Sklearn model as a TileDB array.
-        :param model: An Sklearn Estimator object. Model to store as TileDB array.
         :param update: Boolean. Whether we should update any existing TileDB array
         model at the target location.
         :param meta: Dict. Extra metadata to save in a TileDB array.
         """
         # Serialize model
-        serialized_model = self._serialize_model(model)
+        serialized_model = self._serialize_model()
 
         # Create TileDB model array
         if not update:
             self._create_array()
-
-        self.set_file_properties()
 
         self._write_array(serialized_model=serialized_model, meta=meta)
 
@@ -110,11 +105,9 @@ class SklearnTileDBModel(TileDBModel):
 
             self.update_model_metadata(array=tf_model_tiledb, meta=meta)
 
-    @staticmethod
-    def _serialize_model(model: BaseEstimator) -> bytes:
+    def _serialize_model(self) -> bytes:
         """
         Serializes a Sklearn model with pickle.
-        :param model: A Sklearn Estimator object.
         :return: Bytes. Pickled Sklearn model.
         """
-        return pickle.dumps(model, protocol=4)
+        return pickle.dumps(self.model, protocol=4)

--- a/tiledb/ml/models/tensorflow_keras.py
+++ b/tiledb/ml/models/tensorflow_keras.py
@@ -142,14 +142,10 @@ class TensorflowKerasTileDBModel(TileDBModel):
         :return: str. A string representation of the models internal configuration.
         """
         if self.model:
-            try:
-                s = io.StringIO()
-                self.model.summary(print_fn=lambda x: s.write(x + "\n"))
-                model_summary = s.getvalue()
-                return model_summary
-            # Tensorflow raises value error when it's not able to create a summary, i.e., when model is not built.
-            except ValueError as e:
-                return e
+            s = io.StringIO()
+            self.model.summary(print_fn=lambda x: s.write(x + "\n"))
+            model_summary = s.getvalue()
+            return model_summary
         else:
             return ""
 

--- a/tiledb/ml/models/tensorflow_keras.py
+++ b/tiledb/ml/models/tensorflow_keras.py
@@ -30,40 +30,35 @@ class TensorflowKerasTileDBModel(TileDBModel):
 
     def save(
         self,
-        model: Model,
         include_optimizer: bool = False,
         update: bool = False,
         meta: Optional[dict] = {},
     ):
         """
         Saves a Tensorflow model as a TileDB array.
-        :param model: Tensorflow model.
         :param include_optimizer: Boolean. Whether to save the optimizer or not.
         :param update: Boolean. Whether we should update any existing TileDB array model at the target location.
         :param meta: Dict. Extra metadata to save in a TileDB array.
         """
-        if not isinstance(model, (Functional, Sequential)):
+        if not isinstance(self.model, (Functional, Sequential)):
             raise NotImplementedError(
                 "No support for Subclassed models at the moment. Your "
                 "model should be either Sequential or Functional."
             )
 
         # Serialize model weights and optimizer (if needed)
-        model_weights = pickle.dumps(model.get_weights(), protocol=4)
+        model_weights = pickle.dumps(self.model.get_weights(), protocol=4)
 
         # Serialize model optimizer
         optimizer_weights = self._serialize_optimizer_weights(
-            model=model, include_optimizer=include_optimizer
+            include_optimizer=include_optimizer
         )
 
         # Create TileDB model array
         if not update:
             self._create_array()
 
-        self.set_file_properties()
-
         self._write_array(
-            model=model,
             include_optimizer=include_optimizer,
             serialized_weights=model_weights,
             serialized_optimizer_weights=optimizer_weights,
@@ -147,10 +142,14 @@ class TensorflowKerasTileDBModel(TileDBModel):
         :return: str. A string representation of the models internal configuration.
         """
         if self.model:
-            s = io.StringIO()
-            self.model.summary(print_fn=lambda x: s.write(x + "\n"))
-            model_summary = s.getvalue()
-            return model_summary
+            try:
+                s = io.StringIO()
+                self.model.summary(print_fn=lambda x: s.write(x + "\n"))
+                model_summary = s.getvalue()
+                return model_summary
+            # Tensorflow raises value error when it's not able to create a summary, i.e., when model is not built.
+            except ValueError as e:
+                return e
         else:
             return ""
 
@@ -198,7 +197,6 @@ class TensorflowKerasTileDBModel(TileDBModel):
 
     def _write_array(
         self,
-        model: Model,
         include_optimizer: bool,
         serialized_weights: bytes,
         serialized_optimizer_weights: bytes,
@@ -215,7 +213,7 @@ class TensorflowKerasTileDBModel(TileDBModel):
             }
 
             # Insert all model metadata
-            model_metadata = saving_utils.model_metadata(model, include_optimizer)
+            model_metadata = saving_utils.model_metadata(self.model, include_optimizer)
             for key, value in model_metadata.items():
                 tf_model_tiledb.meta[key] = json.dumps(
                     value, default=json_utils.get_json_type
@@ -223,28 +221,24 @@ class TensorflowKerasTileDBModel(TileDBModel):
 
             self.update_model_metadata(array=tf_model_tiledb, meta=meta)
 
-    @staticmethod
-    def _serialize_model_weights(model: Model) -> bytes:
+    def _serialize_model_weights(self) -> bytes:
         """
         Serialization of model weights
         """
-        return pickle.dumps(model.get_weights(), protocol=4)
+        return pickle.dumps(self.model.get_weights(), protocol=4)
 
-    @staticmethod
-    def _serialize_optimizer_weights(
-        model: Model, include_optimizer: bool = True
-    ) -> bytes:
+    def _serialize_optimizer_weights(self, include_optimizer: bool = True) -> bytes:
         """
         Serialization of optimizer weights
         """
         if (
             include_optimizer
-            and model.optimizer
-            and not isinstance(model.optimizer, optimizer_v1.TFOptimizer)
+            and self.model.optimizer
+            and not isinstance(self.model.optimizer, optimizer_v1.TFOptimizer)
         ):
 
             optimizer_weights = tf.keras.backend.batch_get_value(
-                getattr(model.optimizer, "weights")
+                getattr(self.model.optimizer, "weights")
             )
 
             return pickle.dumps(optimizer_weights, protocol=4)


### PR DESCRIPTION
This PR is about unifying/simplifying model API. We now pass machine learning models (and optimizer for PyTorch) while declaring  a TileDB model array in all frameworks, i.e., Tensorflow Keras, PyTorch and Sklearn. All example model and cloud notebooks and unit tests were changed accordingly. 