### PR TITLE
Removed JSON Serialization

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tiledb-ml
-version = 0.2.2
+version = 0.2.3
 description = Package supports all machine learning functionality for TileDB Embedded and TileDB Cloud
 author = TileDB, Inc.
 author_email = help@tiledb.io

--- a/tiledb/ml/models/base.py
+++ b/tiledb/ml/models/base.py
@@ -3,7 +3,6 @@
 import abc
 import os
 import tiledb
-import json
 import platform
 
 from typing import Optional
@@ -99,7 +98,7 @@ class TileDBModel(abc.ABC):
             )
         else:
             for key, value in {**meta, **self._file_properties}.items():
-                array.meta[key] = json.dumps(value).encode("utf8")
+                array.meta[key] = value
 
     def get_cloud_uri(self, uri: str) -> str:
         from tiledb.ml._cloud_utils import get_s3_prefix


### PR DESCRIPTION
This PR is about removing json serialization from metadata insertion in a model array. This is not needed metadata data types is part of TileDB Embedded and the user should store only supported types.