### PR TITLE
Serverless End-To-End example PyTorch

### DIFF
--- a/examples/serverless/pytorch/README.md
+++ b/examples/serverless/pytorch/README.md
@@ -1,0 +1,15 @@
+<a href="https://tiledb.com"><img src="https://github.com/TileDB-Inc/TileDB/raw/dev/doc/source/_static/tiledb-logo_color_no_margin_@4x.png" alt="TileDB logo" width="400"></a>
+
+This is an end to end example of how to ingest training data, train a model and use it for predictions serverless-ly, by employing UDFs on TileDB-Cloud. 
+In this example, we work on the popular mnist dataset. Firstly, we ingest all training images and labels in TileDB arrays and register them 
+on TileDB-Cloud. We continue by serverless-ly train a model for image classification and save (and register) it as a TileDB array on TileDB-Cloud, 
+and finally, we serverless-ly get some predictions using the trained model. In case you want to run the example, you will need a TileDB-Cloud account as described
+here[](https://docs.tiledb.com/cloud/tutorials/start-here). After signing up, you should export your username and password 
+as environmental variables (**TILEDB_USER_NAME**, **TILEDB_PASSWD**), in order to run ingestion, model training and prediction UDFs. Moreover,
+please add your TileDB namespace and your **S3** bucket in each script.
+
+# Steps
+
+* First, run **data_ingestion.py**. This script will serverless-ly ingest mnist data in two TileDB arrays (one for images, one for labels), created in your S3 bucket, and register them on your TileDB-Cloud account. After running this script, you should be able to see a **mnist_images** array and a **mnist_labels** array in your **Arrays** asset on Tile-DB cloud.
+* Continuing, run **model_training.py**, in order to serverless-ly train a model for classification on the mnist dataset. After running this script, you should be able to see a **mnist_model** array in your **ML Models** asset on TileDB-Cloud.
+* Finally, run **model_load_and_predict.py**, in order to serverless-ly get some predictions using the trained model on your laptop.

--- a/examples/serverless/pytorch/README.md
+++ b/examples/serverless/pytorch/README.md
@@ -1,8 +1,8 @@
 <a href="https://tiledb.com"><img src="https://github.com/TileDB-Inc/TileDB/raw/dev/doc/source/_static/tiledb-logo_color_no_margin_@4x.png" alt="TileDB logo" width="400"></a>
 
 This is an end to end example of how to ingest training data, train a model and use it for predictions serverless-ly, by employing UDFs on TileDB-Cloud. 
-In this example, we work on the popular mnist dataset. Firstly, we ingest all training images and labels in TileDB arrays and register them 
-on TileDB-Cloud. We continue by serverless-ly train a model for image classification and save (and register) it as a TileDB array on TileDB-Cloud, 
+In this example, we work on the popular mnist dataset with TileDB-ML API for dense arrays, i.e., data and labels will be stored as dense TileDB arrays. 
+Firstly, we ingest all training images and labels in TileDB arrays and register them on TileDB-Cloud. We continue by serverless-ly train a model for image classification and save (and register) it as a TileDB array on TileDB-Cloud, 
 and finally, we serverless-ly get some predictions using the trained model. In case you want to run the example, you will need a TileDB-Cloud account as described
 [here](https://docs.tiledb.com/cloud/tutorials/start-here). After signing up, you should export your username and password 
 as environmental variables (**TILEDB_USER_NAME**, **TILEDB_PASSWD**), in order to run ingestion, model training and prediction UDFs. Moreover,

--- a/examples/serverless/pytorch/README.md
+++ b/examples/serverless/pytorch/README.md
@@ -4,7 +4,7 @@ This is an end to end example of how to ingest training data, train a model and 
 In this example, we work on the popular mnist dataset. Firstly, we ingest all training images and labels in TileDB arrays and register them 
 on TileDB-Cloud. We continue by serverless-ly train a model for image classification and save (and register) it as a TileDB array on TileDB-Cloud, 
 and finally, we serverless-ly get some predictions using the trained model. In case you want to run the example, you will need a TileDB-Cloud account as described
-here[](https://docs.tiledb.com/cloud/tutorials/start-here). After signing up, you should export your username and password 
+[here](https://docs.tiledb.com/cloud/tutorials/start-here). After signing up, you should export your username and password 
 as environmental variables (**TILEDB_USER_NAME**, **TILEDB_PASSWD**), in order to run ingestion, model training and prediction UDFs. Moreover,
 please add your TileDB namespace and your **S3** bucket in each script.
 

--- a/examples/serverless/pytorch/data_ingestion.py
+++ b/examples/serverless/pytorch/data_ingestion.py
@@ -1,9 +1,8 @@
 import os
 from typing import Any
 
+import numpy as np
 import tiledb.cloud
-
-from tests.utils import ingest_in_tiledb
 
 # Your TileDB username and password, exported as environmental variables
 TILEDB_USER_NAME = os.environ.get("TILEDB_USER_NAME")
@@ -19,6 +18,35 @@ IMAGES_URI = "tiledb://{}/s3://{}/mnist_images".format(TILEDB_NAMESPACE, S3_BUCK
 LABELS_URI = "tiledb://{}/s3://{}/mnist_labels".format(TILEDB_NAMESPACE, S3_BUCKET)
 
 
+# Let's define an ingestion function
+def ingest_in_tiledb(data: np.array, batch_size: int, uri: str) -> None:
+    import tiledb
+
+    # Equal number of dimensions with the numpy array.
+    dims = [
+        tiledb.Dim(
+            name="dim_" + str(dim),
+            domain=(0, data.shape[dim] - 1),
+            tile=data.shape[dim] if dim > 0 else batch_size,
+            dtype=np.int32,
+        )
+        for dim in range(data.ndim)
+    ]
+
+    # TileDB schema
+    schema = tiledb.ArraySchema(
+        domain=tiledb.Domain(*dims),
+        sparse=False,
+        attrs=[tiledb.Attr(name="features", dtype=data.dtype)],
+    )
+    # Create array
+    tiledb.Array.create(uri, schema)
+
+    # Ingest
+    with tiledb.open(uri, "w") as tiledb_array:
+        tiledb_array[:] = {"features": data}
+
+
 def mnist_ingest(ingestion_func: Any) -> None:
     import torchvision
 
@@ -28,14 +56,10 @@ def mnist_ingest(ingestion_func: Any) -> None:
     labels = train_data.targets.numpy()
 
     # Ingest images
-    ingestion_func(
-        data=images, batch_size=64, uri=IMAGES_URI, sparse=False, num_of_attributes=1
-    )
+    ingestion_func(data=images, batch_size=64, uri=IMAGES_URI)
 
     # Ingest labels
-    ingestion_func(
-        data=labels, batch_size=64, uri=LABELS_URI, sparse=False, num_of_attributes=1
-    )
+    ingestion_func(data=labels, batch_size=64, uri=LABELS_URI)
 
 
 tiledb.cloud.login(username=TILEDB_USER_NAME, password=TILEDB_PASSWD)

--- a/examples/serverless/pytorch/data_ingestion.py
+++ b/examples/serverless/pytorch/data_ingestion.py
@@ -1,8 +1,9 @@
 import os
 from typing import Any
 
-import numpy as np
 import tiledb.cloud
+
+from tests.utils import ingest_in_tiledb
 
 # Your TileDB username and password, exported as environmental variables
 TILEDB_USER_NAME = os.environ.get("TILEDB_USER_NAME")
@@ -18,37 +19,6 @@ IMAGES_URI = "tiledb://{}/s3://{}/mnist_images".format(TILEDB_NAMESPACE, S3_BUCK
 LABELS_URI = "tiledb://{}/s3://{}/mnist_labels".format(TILEDB_NAMESPACE, S3_BUCKET)
 
 
-# Let's define an ingestion function
-def ingest_in_tiledb(data: np.array, batch_size: int, uri: str) -> None:
-    import numpy as np
-
-    import tiledb
-
-    # Equal number of dimensions with the numpy array.
-    dims = [
-        tiledb.Dim(
-            name="dim_" + str(dim),
-            domain=(0, data.shape[dim] - 1),
-            tile=data.shape[dim] if dim > 0 else batch_size,
-            dtype=np.int32,
-        )
-        for dim in range(data.ndim)
-    ]
-
-    # TileDB schema
-    schema = tiledb.ArraySchema(
-        domain=tiledb.Domain(*dims),
-        sparse=False,
-        attrs=[tiledb.Attr(name="features", dtype=data.dtype)],
-    )
-    # Create array
-    tiledb.Array.create(uri, schema)
-
-    # Ingest
-    with tiledb.open(uri, "w") as tiledb_array:
-        tiledb_array[:] = {"features": data}
-
-
 def mnist_ingest(ingestion_func: Any) -> None:
     import torchvision
 
@@ -58,10 +28,14 @@ def mnist_ingest(ingestion_func: Any) -> None:
     labels = train_data.targets.numpy()
 
     # Ingest images
-    ingestion_func(data=images, batch_size=64, uri=IMAGES_URI)
+    ingestion_func(
+        data=images, batch_size=64, uri=IMAGES_URI, sparse=False, num_of_attributes=1
+    )
 
     # Ingest labels
-    ingestion_func(data=labels, batch_size=64, uri=LABELS_URI)
+    ingestion_func(
+        data=labels, batch_size=64, uri=LABELS_URI, sparse=False, num_of_attributes=1
+    )
 
 
 tiledb.cloud.login(username=TILEDB_USER_NAME, password=TILEDB_PASSWD)

--- a/examples/serverless/pytorch/data_ingestion.py
+++ b/examples/serverless/pytorch/data_ingestion.py
@@ -1,0 +1,71 @@
+import os
+from typing import Any
+
+import numpy as np
+import tiledb.cloud
+
+# Your TileDB username and password, exported as environmental variables
+TILEDB_USER_NAME = os.environ.get("TILEDB_USER_NAME")
+TILEDB_PASSWD = os.environ.get("TILEDB_PASSWD")
+
+# Your TileDB namespace
+TILEDB_NAMESPACE = "your_tiledb_namespace"
+
+# Your S3 bucket
+S3_BUCKET = "your_s3_bucket"
+
+IMAGES_URI = "tiledb://{}/s3://{}/mnist_images".format(TILEDB_NAMESPACE, S3_BUCKET)
+LABELS_URI = "tiledb://{}/s3://{}/mnist_labels".format(TILEDB_NAMESPACE, S3_BUCKET)
+
+
+# Let's define an ingestion function
+def ingest_in_tiledb(data: np.array, batch_size: int, uri: str) -> None:
+    import numpy as np
+
+    import tiledb
+
+    # Equal number of dimensions with the numpy array.
+    dims = [
+        tiledb.Dim(
+            name="dim_" + str(dim),
+            domain=(0, data.shape[dim] - 1),
+            tile=data.shape[dim] if dim > 0 else batch_size,
+            dtype=np.int32,
+        )
+        for dim in range(data.ndim)
+    ]
+
+    # TileDB schema
+    schema = tiledb.ArraySchema(
+        domain=tiledb.Domain(*dims),
+        sparse=False,
+        attrs=[tiledb.Attr(name="features", dtype=data.dtype)],
+    )
+    # Create array
+    tiledb.Array.create(uri, schema)
+
+    # Ingest
+    with tiledb.open(uri, "w") as tiledb_array:
+        tiledb_array[:] = {"features": data}
+
+
+def mnist_ingest(ingestion_func: Any) -> None:
+    import torchvision
+
+    train_data = torchvision.datasets.MNIST("./data", train=True, download=True)
+
+    images = train_data.data.numpy() / 255.0
+    labels = train_data.targets.numpy()
+
+    # Ingest images
+    ingestion_func(data=images, batch_size=64, uri=IMAGES_URI)
+
+    # Ingest labels
+    ingestion_func(data=labels, batch_size=64, uri=LABELS_URI)
+
+
+tiledb.cloud.login(username=TILEDB_USER_NAME, password=TILEDB_PASSWD)
+
+tiledb.cloud.udf.exec(mnist_ingest, ingestion_func=ingest_in_tiledb)
+
+print(tiledb.cloud.last_udf_task().logs)

--- a/examples/serverless/pytorch/model_load_and_predict.py
+++ b/examples/serverless/pytorch/model_load_and_predict.py
@@ -8,20 +8,14 @@ TILEDB_USER_NAME = os.environ.get("TILEDB_USER_NAME")
 TILEDB_PASSWD = os.environ.get("TILEDB_PASSWD")
 
 # Your TileDB namespace
-TILEDB_NAMESPACE = "gskoumas"
+TILEDB_NAMESPACE = "your_tiledb_namespace"
 
 # Your S3 bucket
-S3_BUCKET = "tiledb-gskoumas"
+S3_BUCKET = "your_s3_bucket"
 
-IMAGES_URI = "tiledb://{}/s3://{}/arrays/mnist_images".format(
-    TILEDB_NAMESPACE, S3_BUCKET
-)
-LABELS_URI = "tiledb://{}/s3://{}/arrays/mnist_labels".format(
-    TILEDB_NAMESPACE, S3_BUCKET
-)
-MODEL_URI = "tiledb://{}/s3://{}/ml_models/mnist_model".format(
-    TILEDB_NAMESPACE, S3_BUCKET
-)
+IMAGES_URI = "tiledb://{}/s3://{}/mnist_images".format(TILEDB_NAMESPACE, S3_BUCKET)
+LABELS_URI = "tiledb://{}/s3://{}/mnist_labels".format(TILEDB_NAMESPACE, S3_BUCKET)
+MODEL_URI = "tiledb://{}/s3://{}/mnist_model".format(TILEDB_NAMESPACE, S3_BUCKET)
 
 IO_BATCH_SIZE = 20000
 

--- a/examples/serverless/pytorch/model_load_and_predict.py
+++ b/examples/serverless/pytorch/model_load_and_predict.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, List, Tuple
+from typing import List
 
 import tiledb.cloud
 
@@ -21,6 +21,8 @@ IO_BATCH_SIZE = 20000
 
 
 def predict() -> List[int]:
+    from typing import Any, Tuple
+
     import numpy as np
     import torch
     import torch.nn as nn

--- a/examples/serverless/pytorch/model_load_and_predict.py
+++ b/examples/serverless/pytorch/model_load_and_predict.py
@@ -57,8 +57,8 @@ def predict() -> List[int]:
         model=loaded_model, optimizer=loaded_optimizer
     )
 
-    with torch.no_grad():  # type: ignore
-        with tiledb.open(IMAGES_URI) as x, tiledb.open(LABELS_URI) as y:
+    with tiledb.open(IMAGES_URI) as x, tiledb.open(LABELS_URI) as y:
+        with torch.no_grad():  # type: ignore
             tiledb_dataset = PyTorchTileDBDenseDataset(
                 x_array=x, y_array=y, batch_size=IO_BATCH_SIZE
             )

--- a/examples/serverless/pytorch/model_load_and_predict.py
+++ b/examples/serverless/pytorch/model_load_and_predict.py
@@ -33,7 +33,7 @@ def predict() -> List[int]:
 
     class Net(nn.Module):
         def __init__(self, shape: Tuple[int, int]):
-            super(Net, self).__init__()
+            super().__init__()  # type: ignore
             self.flatten = nn.Flatten()
             self.linear_relu_stack = nn.Sequential(
                 nn.Linear(np.product(shape), 32),
@@ -57,7 +57,7 @@ def predict() -> List[int]:
         model=loaded_model, optimizer=loaded_optimizer
     )
 
-    with torch.no_grad():
+    with torch.no_grad():  # type: ignore
         with tiledb.open(IMAGES_URI) as x, tiledb.open(LABELS_URI) as y:
             tiledb_dataset = PyTorchTileDBDenseDataset(
                 x_array=x, y_array=y, batch_size=IO_BATCH_SIZE

--- a/examples/serverless/pytorch/model_load_and_predict.py
+++ b/examples/serverless/pytorch/model_load_and_predict.py
@@ -8,14 +8,20 @@ TILEDB_USER_NAME = os.environ.get("TILEDB_USER_NAME")
 TILEDB_PASSWD = os.environ.get("TILEDB_PASSWD")
 
 # Your TileDB namespace
-TILEDB_NAMESPACE = "your_tiledb_namespace"
+TILEDB_NAMESPACE = "gskoumas"
 
 # Your S3 bucket
-S3_BUCKET = "your_s3_bucket"
+S3_BUCKET = "tiledb-gskoumas"
 
-IMAGES_URI = "tiledb://{}/s3://{}/mnist_images".format(TILEDB_NAMESPACE, S3_BUCKET)
-LABELS_URI = "tiledb://{}/s3://{}/mnist_labels".format(TILEDB_NAMESPACE, S3_BUCKET)
-MODEL_URI = "tiledb://{}/s3://{}/mnist_model".format(TILEDB_NAMESPACE, S3_BUCKET)
+IMAGES_URI = "tiledb://{}/s3://{}/arrays/mnist_images".format(
+    TILEDB_NAMESPACE, S3_BUCKET
+)
+LABELS_URI = "tiledb://{}/s3://{}/arrays/mnist_labels".format(
+    TILEDB_NAMESPACE, S3_BUCKET
+)
+MODEL_URI = "tiledb://{}/s3://{}/ml_models/mnist_model".format(
+    TILEDB_NAMESPACE, S3_BUCKET
+)
 
 IO_BATCH_SIZE = 20000
 

--- a/examples/serverless/pytorch/model_load_and_predict.py
+++ b/examples/serverless/pytorch/model_load_and_predict.py
@@ -1,0 +1,80 @@
+import os
+from typing import Any, List, Tuple
+
+import tiledb.cloud
+
+# Your TileDB username and password, exported as environmental variables
+TILEDB_USER_NAME = os.environ.get("TILEDB_USER_NAME")
+TILEDB_PASSWD = os.environ.get("TILEDB_PASSWD")
+
+# Your TileDB namespace
+TILEDB_NAMESPACE = "your_tiledb_namespace"
+
+# Your S3 bucket
+S3_BUCKET = "your_s3_bucket"
+
+IMAGES_URI = "tiledb://{}/s3://{}/mnist_images".format(TILEDB_NAMESPACE, S3_BUCKET)
+LABELS_URI = "tiledb://{}/s3://{}/mnist_labels".format(TILEDB_NAMESPACE, S3_BUCKET)
+MODEL_URI = "tiledb://{}/s3://{}/mnist_model".format(TILEDB_NAMESPACE, S3_BUCKET)
+
+IO_BATCH_SIZE = 20000
+
+
+def predict() -> List[int]:
+    import numpy as np
+    import torch
+    import torch.nn as nn
+    import torch.optim as optim
+
+    from tiledb.ml.models.pytorch import PyTorchTileDBModel
+    from tiledb.ml.readers.pytorch import PyTorchTileDBDenseDataset
+
+    class Net(nn.Module):
+        def __init__(self, shape: Tuple[int, int]):
+            super(Net, self).__init__()
+            self.flatten = nn.Flatten()
+            self.linear_relu_stack = nn.Sequential(
+                nn.Linear(np.product(shape), 32),
+                nn.ReLU(),
+                nn.Linear(32, 32),
+                nn.ReLU(),
+                nn.Linear(32, 10),
+                nn.ReLU(),
+            )
+
+        def forward(self, x: torch.Tensor) -> Any:
+            x = self.flatten(x)
+            logits = self.linear_relu_stack(x)
+            return logits
+
+    # Load our model from a TileDB array
+    loaded_model = Net(shape=(28, 28))
+    loaded_optimizer = optim.SGD(loaded_model.parameters(), lr=0.01, momentum=0.5)
+
+    PyTorchTileDBModel(uri=MODEL_URI).load(
+        model=loaded_model, optimizer=loaded_optimizer
+    )
+
+    with torch.no_grad():
+        with tiledb.open(IMAGES_URI) as x, tiledb.open(LABELS_URI) as y:
+            tiledb_dataset = PyTorchTileDBDenseDataset(
+                x_array=x, y_array=y, batch_size=IO_BATCH_SIZE
+            )
+            data_loader = torch.utils.data.DataLoader(tiledb_dataset, batch_size=None)
+
+            inputs, labels = next(iter(data_loader))
+
+            output = loaded_model(
+                inputs[np.random.randint(0, 10) : np.random.randint(11, 50)].to(
+                    torch.float
+                )
+            )
+
+    return [np.argmax(pred) for pred in output.numpy()]
+
+
+tiledb.cloud.login(username=TILEDB_USER_NAME, password=TILEDB_PASSWD)
+
+predictions = tiledb.cloud.udf.exec(predict)
+
+print(predictions)

--- a/examples/serverless/pytorch/model_training.py
+++ b/examples/serverless/pytorch/model_training.py
@@ -33,7 +33,7 @@ def train() -> None:
 
     class Net(nn.Module):
         def __init__(self, shape: Tuple[int, int]):
-            super(Net, self).__init__()
+            super().__init__()  # type: ignore
             self.flatten = nn.Flatten()
             self.linear_relu_stack = nn.Sequential(
                 nn.Linear(np.product(shape), 32),

--- a/examples/serverless/pytorch/model_training.py
+++ b/examples/serverless/pytorch/model_training.py
@@ -1,0 +1,111 @@
+import os
+from typing import Any, Tuple
+
+import tiledb.cloud
+
+# Your TileDB username and password, exported as environmental variables
+TILEDB_USER_NAME = os.environ.get("TILEDB_USER_NAME")
+TILEDB_PASSWD = os.environ.get("TILEDB_PASSWD")
+
+# Your TileDB namespace
+TILEDB_NAMESPACE = "your_tiledb_namespace"
+
+# Your S3 bucket
+S3_BUCKET = "your_s3_bucket"
+
+IMAGES_URI = "tiledb://{}/s3://{}/mnist_images".format(TILEDB_NAMESPACE, S3_BUCKET)
+LABELS_URI = "tiledb://{}/s3://{}/mnist_labels".format(TILEDB_NAMESPACE, S3_BUCKET)
+MODEL_URI = "tiledb://{}/s3://{}/mnist_model".format(TILEDB_NAMESPACE, S3_BUCKET)
+
+# The size of each slice from a image and label TileDB arrays.
+IO_BATCH_SIZE = 20000
+
+
+def train() -> None:
+    import numpy as np
+    import torch
+    import torch.nn as nn
+    import torch.optim as optim
+
+    from tiledb.ml.models.pytorch import PyTorchTileDBModel
+    from tiledb.ml.readers.pytorch import PyTorchTileDBDenseDataset
+
+    class Net(nn.Module):
+        def __init__(self, shape: Tuple[int, int]):
+            super().__init__()
+            self.flatten = nn.Flatten()
+            self.linear_relu_stack = nn.Sequential(
+                nn.Linear(np.product(shape), 32),
+                nn.ReLU(),
+                nn.Linear(32, 32),
+                nn.ReLU(),
+                nn.Linear(32, 10),
+                nn.ReLU(),
+            )
+
+        def forward(self, x: torch.Tensor) -> Any:
+            x = self.flatten(x)
+            logits = self.linear_relu_stack(x)
+            return logits
+
+    with tiledb.open(IMAGES_URI) as x, tiledb.open(LABELS_URI) as y:
+        tiledb_dataset = PyTorchTileDBDenseDataset(
+            x_array=x, y_array=y, batch_size=IO_BATCH_SIZE
+        )
+        train_loader = torch.utils.data.DataLoader(tiledb_dataset, batch_size=None)
+
+        net = Net(shape=(28, 28))
+        criterion = nn.CrossEntropyLoss()
+        optimizer = optim.SGD(net.parameters(), lr=0.01, momentum=0.5)
+
+        training_batch_size = 200
+
+        for epoch in range(1, 3):
+            net.train()
+            training_batch_idx = 0
+            for batch_idx, (inputs, labels) in enumerate(train_loader):
+                for train_batch_start_idx in range(0, 20000, training_batch_size):
+                    # zero the parameter gradients
+                    optimizer.zero_grad()
+                    # forward + backward + optimize
+                    outputs = net(
+                        inputs[
+                            train_batch_start_idx : train_batch_start_idx
+                            + training_batch_size
+                        ].to(torch.float)
+                    )
+                    loss = criterion(
+                        outputs,
+                        labels[
+                            train_batch_start_idx : train_batch_start_idx
+                            + training_batch_size
+                        ]
+                        .to(torch.float)
+                        .type(torch.LongTensor),
+                    )
+                    loss.backward()
+                    optimizer.step()
+                    if training_batch_idx % 100 == 0:
+                        print(
+                            "Train Epoch: {} Batch: {} Loss: {:.6f}".format(
+                                epoch, training_batch_idx, loss.item()
+                            )
+                        )
+                    training_batch_idx += 1
+
+        model = PyTorchTileDBModel(
+            uri="mnist_model",
+            namespace=TILEDB_NAMESPACE,
+            model=net,
+            optimizer=optimizer,
+        )
+
+        # Save model as TileDB array.
+        model.save()
+
+
+tiledb.cloud.login(username=TILEDB_USER_NAME, password=TILEDB_PASSWD)
+
+tiledb.cloud.udf.exec(train)
+
+print(tiledb.cloud.last_udf_task().logs)

--- a/examples/serverless/pytorch/model_training.py
+++ b/examples/serverless/pytorch/model_training.py
@@ -33,7 +33,7 @@ def train() -> None:
 
     class Net(nn.Module):
         def __init__(self, shape: Tuple[int, int]):
-            super().__init__()
+            super(Net, self).__init__()
             self.flatten = nn.Flatten()
             self.linear_relu_stack = nn.Sequential(
                 nn.Linear(np.product(shape), 32),

--- a/examples/serverless/pytorch/model_training.py
+++ b/examples/serverless/pytorch/model_training.py
@@ -65,7 +65,9 @@ def train() -> None:
             net.train()
             training_batch_idx = 0
             for batch_idx, (inputs, labels) in enumerate(train_loader):
-                for train_batch_start_idx in range(0, 20000, training_batch_size):
+                for train_batch_start_idx in range(
+                    0, IO_BATCH_SIZE, training_batch_size
+                ):
                     # zero the parameter gradients
                     optimizer.zero_grad()
                     # forward + backward + optimize

--- a/examples/serverless/pytorch/model_training.py
+++ b/examples/serverless/pytorch/model_training.py
@@ -1,5 +1,4 @@
 import os
-from typing import Any, Tuple
 
 import tiledb.cloud
 
@@ -22,6 +21,8 @@ IO_BATCH_SIZE = 20000
 
 
 def train() -> None:
+    from typing import Any, Tuple
+
     import numpy as np
     import torch
     import torch.nn as nn

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ disallow_any_generics = True
 #disallow_subclassing_any = True
 
 # Untyped definitions and calls
-disallow_untyped_calls = False
+disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_decorators = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ disallow_any_generics = True
 #disallow_subclassing_any = True
 
 # Untyped definitions and calls
-disallow_untyped_calls = True
+# disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_decorators = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ disallow_any_generics = True
 #disallow_subclassing_any = True
 
 # Untyped definitions and calls
-disallow_untyped_calls = True
+disallow_untyped_calls = False
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_decorators = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ disallow_any_generics = True
 #disallow_subclassing_any = True
 
 # Untyped definitions and calls
-disallow_untyped_calls = True
+# disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_decorators = True
@@ -84,7 +84,7 @@ strict_optional = True
 
 # Configuring warnings
 warn_redundant_casts = True
-warn_unused_ignores = True
+warn_unused_ignores = False
 warn_no_return = True
 warn_return_any = True
 warn_unreachable = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ disallow_any_generics = True
 #disallow_subclassing_any = True
 
 # Untyped definitions and calls
-# disallow_untyped_calls = True
+disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_decorators = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ disallow_any_generics = True
 #disallow_subclassing_any = True
 
 # Untyped definitions and calls
-# disallow_untyped_calls = True
+disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_decorators = True
@@ -84,7 +84,7 @@ strict_optional = True
 
 # Configuring warnings
 warn_redundant_casts = True
-warn_unused_ignores = False
+warn_unused_ignores = True
 warn_no_return = True
 warn_return_any = True
 warn_unreachable = True


### PR DESCRIPTION
This PR is about an _end to end_ example of how to ingest the MNIST dataset, train a model and use it for predictions completely serverless-ly, with  the use of UDFs on TileDB-Cloud.