### PR TITLE
[Fix/Enhancement] Adding default argument current time timestamp in open 'w' mode

### DIFF
--- a/tiledb/ml/models/base.py
+++ b/tiledb/ml/models/base.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import time
 from abc import ABC, abstractmethod
 from enum import Enum, unique
 from typing import Any, Generic, Mapping, Optional, Tuple, TypeVar
@@ -24,6 +25,10 @@ class ModelFileProperties(Enum):
     TILEDB_ML_MODEL_STAGE = "TILEDB_ML_MODEL_STAGE"
     TILEDB_ML_MODEL_PYTHON_VERSION = "TILEDB_ML_MODEL_PYTHON_VERSION"
     TILEDB_ML_MODEL_PREVIEW = "TILEDB_ML_MODEL_PREVIEW"
+
+
+def current_milli_time() -> int:
+    return round(time.time() * 1000)
 
 
 class TileDBModel(ABC, Generic[Model]):

--- a/tiledb/ml/models/pytorch.py
+++ b/tiledb/ml/models/pytorch.py
@@ -102,6 +102,8 @@ class PyTorchTileDBModel(TileDBModel[torch.nn.Module]):
         :param optimizer: A defined PyTorch optimizer.
         :return: A dictionary with attributes other than model or optimizer state_dict.
         """
+
+        # TODO: Change timestamp when issue in core is resolved
         model_array = tiledb.open(self.uri, ctx=self.ctx, timestamp=timestamp)
         model_array_results = model_array[:]
         schema = model_array.schema
@@ -211,6 +213,8 @@ class PyTorchTileDBModel(TileDBModel[torch.nn.Module]):
             optimizer state, extra model information) of a PyTorch model.
         :param meta: Extra metadata to save in a TileDB array.
         """
+
+        # TODO: Change timestamp when issue in core is resolved
         with tiledb.open(
             self.uri, "w", timestamp=current_milli_time(), ctx=self.ctx
         ) as tf_model_tiledb:

--- a/tiledb/ml/models/pytorch.py
+++ b/tiledb/ml/models/pytorch.py
@@ -9,7 +9,7 @@ from torch.optim import Optimizer
 
 import tiledb
 
-from .base import Meta, TileDBModel, Timestamp
+from .base import Meta, TileDBModel, Timestamp, current_milli_time
 
 
 class PyTorchTileDBModel(TileDBModel[torch.nn.Module]):
@@ -211,7 +211,9 @@ class PyTorchTileDBModel(TileDBModel[torch.nn.Module]):
             optimizer state, extra model information) of a PyTorch model.
         :param meta: Extra metadata to save in a TileDB array.
         """
-        with tiledb.open(self.uri, "w", ctx=self.ctx) as tf_model_tiledb:
+        with tiledb.open(
+            self.uri, "w", timestamp=current_milli_time(), ctx=self.ctx
+        ) as tf_model_tiledb:
             # Insertion in TileDB array
             tf_model_tiledb[:] = {
                 key: np.array([value]) for key, value in serialized_model_dict.items()

--- a/tiledb/ml/models/sklearn.py
+++ b/tiledb/ml/models/sklearn.py
@@ -47,6 +47,8 @@ class SklearnTileDBModel(TileDBModel[BaseEstimator]):
             in the specified time range.
         :return: A Sklearn model object.
         """
+        # TODO: Change timestamp when issue in core is resolved
+
         model_array = tiledb.open(self.uri, ctx=self.ctx, timestamp=timestamp)
         model_array_results = model_array[:]
         model = pickle.loads(model_array_results["model_params"].item(0))
@@ -102,6 +104,8 @@ class SklearnTileDBModel(TileDBModel[BaseEstimator]):
         :param serialized_model: A pickled sklearn model.
         :param meta: Extra metadata to save in a TileDB array.
         """
+        # TODO: Change timestamp when issue in core is resolved
+
         with tiledb.open(
             self.uri, "w", timestamp=current_milli_time(), ctx=self.ctx
         ) as tf_model_tiledb:

--- a/tiledb/ml/models/sklearn.py
+++ b/tiledb/ml/models/sklearn.py
@@ -10,7 +10,7 @@ from sklearn.base import BaseEstimator
 
 import tiledb
 
-from .base import Meta, TileDBModel, Timestamp
+from .base import Meta, TileDBModel, Timestamp, current_milli_time
 
 
 class SklearnTileDBModel(TileDBModel[BaseEstimator]):
@@ -102,7 +102,9 @@ class SklearnTileDBModel(TileDBModel[BaseEstimator]):
         :param serialized_model: A pickled sklearn model.
         :param meta: Extra metadata to save in a TileDB array.
         """
-        with tiledb.open(self.uri, "w", ctx=self.ctx) as tf_model_tiledb:
+        with tiledb.open(
+            self.uri, "w", timestamp=current_milli_time(), ctx=self.ctx
+        ) as tf_model_tiledb:
             # Insertion in TileDB array
             tf_model_tiledb[:] = {"model_params": np.array([serialized_model])}
             self.update_model_metadata(array=tf_model_tiledb, meta=meta)

--- a/tiledb/ml/models/tensorflow_keras.py
+++ b/tiledb/ml/models/tensorflow_keras.py
@@ -20,7 +20,7 @@ from tensorflow.python.keras.utils import generic_utils
 
 import tiledb
 
-from .base import Meta, TileDBModel, Timestamp
+from .base import Meta, TileDBModel, Timestamp, current_milli_time
 
 
 class TensorflowKerasTileDBModel(TileDBModel[tf.keras.Model]):
@@ -257,7 +257,9 @@ class TensorflowKerasTileDBModel(TileDBModel[tf.keras.Model]):
     ) -> None:
         """Write Tensorflow model to a TileDB array."""
         assert self.model
-        with tiledb.open(self.uri, "w", ctx=self.ctx) as tf_model_tiledb:
+        with tiledb.open(
+            self.uri, "w", timestamp=current_milli_time(), ctx=self.ctx
+        ) as tf_model_tiledb:
             if isinstance(self.model, (Functional, Sequential)):
                 tf_model_tiledb[:] = {
                     "model_weights": np.array([serialized_weights]),

--- a/tiledb/ml/models/tensorflow_keras.py
+++ b/tiledb/ml/models/tensorflow_keras.py
@@ -88,6 +88,8 @@ class TensorflowKerasTileDBModel(TileDBModel[tf.keras.Model]):
         :param input_shape: The shape that the custom model expects as input
         :return: Tensorflow model.
         """
+        # TODO: Change timestamp when issue in core is resolved
+
         with tiledb.open(self.uri, ctx=self.ctx, timestamp=timestamp) as model_array:
             model_array_results = model_array[:]
             model_config = json.loads(model_array.meta["model_config"])
@@ -257,6 +259,7 @@ class TensorflowKerasTileDBModel(TileDBModel[tf.keras.Model]):
     ) -> None:
         """Write Tensorflow model to a TileDB array."""
         assert self.model
+        # TODO: Change timestamp when issue in core is resolved
         with tiledb.open(
             self.uri, "w", timestamp=current_milli_time(), ctx=self.ctx
         ) as tf_model_tiledb:


### PR DESCRIPTION
We modify each `open` operation adding current timestamp argument, when modifying/writing arrays to patch the bug described in the ticket below. This patch needs the upgrade of TileDB-Py to its currently latest release being [0.11.0](https://github.com/TileDB-Inc/TileDB-Py/releases/tag/0.11.0) without it the issue persists due to the array.create function that was patched in the aforementioned release.

Files changed:
```
tiledb/ml/models/base.py
tiledb/ml/models/pytorch.py
tiledb/ml/models/tensorflow.py
tiledb/ml/models/sklearn.py

```
