### PR TITLE
Add dense and sparse checks  in Tensoflow and PyTorch data APIs

### DIFF
--- a/tests/test_pytorch_dataloader_api.py
+++ b/tests/test_pytorch_dataloader_api.py
@@ -104,6 +104,51 @@ class TestPytorchDenseDataloader:
 
             assert isinstance(tiledb_dataset, torch.utils.data.IterableDataset)
 
+    def test_except_with_sparse_x_array(
+        self,
+        tmpdir,
+        input_shape,
+        workers,
+        num_of_attributes,
+        batch_shuffle,
+        within_batch_shuffle,
+        buffer_size,
+    ):
+        tiledb_uri_x = os.path.join(tmpdir, "x")
+        tiledb_uri_y = os.path.join(tmpdir, "y")
+
+        ingest_in_tiledb(
+            uri=tiledb_uri_x,
+            data=np.random.rand(ROWS, *input_shape),
+            batch_size=BATCH_SIZE,
+            sparse=True,
+            num_of_attributes=num_of_attributes,
+        )
+        ingest_in_tiledb(
+            uri=tiledb_uri_y,
+            data=np.random.randint(low=0, high=NUM_OF_CLASSES, size=ROWS),
+            batch_size=BATCH_SIZE,
+            sparse=False,
+            num_of_attributes=num_of_attributes,
+        )
+
+        with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
+            with pytest.raises(TypeError):
+                PyTorchTileDBDenseDataset(
+                    x_array=x,
+                    y_array=y,
+                    batch_size=BATCH_SIZE,
+                    buffer_size=buffer_size,
+                    batch_shuffle=batch_shuffle,
+                    within_batch_shuffle=within_batch_shuffle,
+                    x_attribute_names=[
+                        "features_" + str(attr) for attr in range(num_of_attributes)
+                    ],
+                    y_attribute_names=[
+                        "features_" + str(attr) for attr in range(num_of_attributes)
+                    ],
+                )
+
     def test_except_with_diff_number_of_x_y_rows(
         self,
         tmpdir,

--- a/tests/test_pytorch_sparse_dataloader_api.py
+++ b/tests/test_pytorch_sparse_dataloader_api.py
@@ -43,6 +43,49 @@ ROWS = 100
     [50, None],
 )
 class TestTileDBSparsePyTorchDataloaderAPI:
+    def test_except_with_dense_x_array(
+        self,
+        tmpdir,
+        input_shape,
+        workers,
+        num_of_attributes,
+        batch_shuffle,
+        buffer_size,
+    ):
+        tiledb_uri_x = os.path.join(tmpdir, "x")
+        tiledb_uri_y = os.path.join(tmpdir, "y")
+
+        ingest_in_tiledb(
+            uri=tiledb_uri_x,
+            data=np.random.rand(ROWS, *input_shape),
+            batch_size=BATCH_SIZE,
+            sparse=False,
+            num_of_attributes=num_of_attributes,
+        )
+        ingest_in_tiledb(
+            uri=tiledb_uri_y,
+            data=np.random.randint(low=0, high=NUM_OF_CLASSES, size=ROWS),
+            batch_size=BATCH_SIZE,
+            sparse=False,
+            num_of_attributes=num_of_attributes,
+        )
+
+        with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
+            with pytest.raises(TypeError):
+                PyTorchTileDBSparseDataset(
+                    x_array=x,
+                    y_array=y,
+                    batch_size=BATCH_SIZE,
+                    buffer_size=buffer_size,
+                    batch_shuffle=batch_shuffle,
+                    x_attribute_names=[
+                        "features_" + str(attr) for attr in range(num_of_attributes)
+                    ],
+                    y_attribute_names=[
+                        "features_" + str(attr) for attr in range(num_of_attributes)
+                    ],
+                )
+
     def test_tiledb_pytorch_sparse_data_api_with_sparse_data_sparse_label(
         self,
         tmpdir,

--- a/tests/test_tensorflow_data_api.py
+++ b/tests/test_tensorflow_data_api.py
@@ -107,6 +107,64 @@ class TestTileDBTensorflowDataAPI:
 
             assert isinstance(tiledb_dataset, tf.data.Dataset)
 
+    def test_except_with_sparse_x_array(
+        self,
+        tmpdir,
+        input_shape,
+        num_of_attributes,
+        batch_shuffle,
+        within_batch_shuffle,
+        buffer_size,
+    ):
+        array_uuid = str(uuid.uuid4())
+        tiledb_uri_x = os.path.join(tmpdir, "x" + array_uuid)
+        tiledb_uri_y = os.path.join(tmpdir, "y" + array_uuid)
+
+        ingest_in_tiledb(
+            uri=tiledb_uri_x,
+            data=np.random.rand(ROWS, *input_shape[1:]),
+            batch_size=BATCH_SIZE,
+            sparse=True,
+            num_of_attributes=num_of_attributes,
+        )
+
+        ingest_in_tiledb(
+            uri=tiledb_uri_y,
+            data=np.random.rand(ROWS, NUM_OF_CLASSES),
+            batch_size=BATCH_SIZE,
+            sparse=False,
+            num_of_attributes=num_of_attributes,
+        )
+
+        with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
+            with pytest.raises(TypeError):
+                TensorflowTileDBDenseDataset(
+                    x_array=x,
+                    y_array=y,
+                    batch_size=BATCH_SIZE,
+                    batch_shuffle=batch_shuffle,
+                    buffer_size=buffer_size,
+                    within_batch_shuffle=within_batch_shuffle,
+                    x_attribute_names=[
+                        "features_" + str(attr) for attr in range(num_of_attributes)
+                    ],
+                    y_attribute_names=[
+                        "features_" + str(attr) for attr in range(num_of_attributes)
+                    ],
+                )
+
+        # Same test without attribute names explicitly provided by the user
+        with tiledb.open(tiledb_uri_x) as x, tiledb.open(tiledb_uri_y) as y:
+            with pytest.raises(TypeError):
+                TensorflowTileDBDenseDataset(
+                    x_array=x,
+                    y_array=y,
+                    batch_size=BATCH_SIZE,
+                    batch_shuffle=batch_shuffle,
+                    buffer_size=buffer_size,
+                    within_batch_shuffle=within_batch_shuffle,
+                )
+
     def test_except_with_diff_number_of_x_y_rows(
         self,
         tmpdir,

--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -56,6 +56,10 @@ class PyTorchTileDBDenseDataset(torch.utils.data.IterableDataset[DataType]):
         :param x_attribute_names: The attribute names of x_array.
         :param y_attribute_names: The attribute names of y_array.
         """
+        if type(x_array) is tiledb.SparseArray:
+            raise TypeError(
+                "PyTorchTileDBDenseDataset class should be used with tiledb.DenseArray representation"
+            )
 
         # Check that x and y have the same number of rows
         if x_array.schema.domain.shape[0] != y_array.schema.domain.shape[0]:

--- a/tiledb/ml/readers/tensorflow.py
+++ b/tiledb/ml/readers/tensorflow.py
@@ -53,6 +53,10 @@ class TensorflowTileDBDenseDataset(FlatMapDataset):
         :param x_attribute_names: The attribute names of x_array.
         :param y_attribute_names: The attribute names of y_array.
         """
+        if type(x_array) is tiledb.SparseArray:
+            raise TypeError(
+                "TensorflowTileDBDenseDataset class should be used with tiledb.DenseArray representation"
+            )
 
         # Check that x and y have the same number of rows
         if x_array.schema.domain.shape[0] != y_array.schema.domain.shape[0]:


### PR DESCRIPTION
This PR is about adding checks for Dense and Sparse X arrays in both Dense and Sparse cases for both Tensorflow and PyTorch data APIs. Unit tests for all cases are also included.