### PR TITLE
Test tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,36 +17,28 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: 'Print python version'
-      run: |
-        which python
-        which pip
-        python --version
-
-    - name: 'Upgrade pip'
-      run: python -m pip install --upgrade pip
-
     - name: 'Install dependencies'
-      run: pip install -e .[full]
-
-    - name: 'Run tests'
-      if: ${{ matrix.os != 'macos-latest' }}
       run: |
-        pip install pytest-mock pytest-cov
-        pytest tests/
+        pip install --upgrade pip
+        pip install -e .[full]
 
-    - name: Run mypy
-      if: ${{ matrix.os != 'macos-latest' }}
+    - name: 'Run mypy'
       run: |
         pip install mypy
         mypy .
+
+    - name: 'Run tests'
+      if: ${{ matrix.os != 'macos-latest' || matrix.python-version != '3.7' }}
+      run: |
+        pip install pytest-mock pytest-xdist
+        pytest -n auto tests/
 
     - name: 'Run test coverage statistics'
       id: stats
       if: ${{ matrix.os == 'macos-latest' && matrix.python-version == '3.7' }}
       run: |
-        pip install pytest-mock pytest-cov
-        TEST_COVERAGE="$(pytest --cov-report term:skip-covered --cov=tiledb tests/ | grep '^TOTAL' | awk -v N=4 '{print $N}')"
+        pip install pytest-mock pytest-xdist pytest-cov
+        TEST_COVERAGE="$(pytest -n auto --cov-report=term-missing --cov=tiledb tests/ | grep '^TOTAL' | awk -v N=4 '{print $N}')"
         echo "::set-output name=COVERAGE::$TEST_COVERAGE"
 
     - name: 'Create Test Coverage Badge'

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,9 +46,6 @@ pytorch_cloud = torch>=1.8.1, <1.10; torchvision>=0.9.1; tiledb-cloud>=0.7.11
 sklearn_cloud = scikit-learn>=0.23.0; tiledb-cloud>=0.7.11
 full = tensorflow<=2.5.0; torch>=1.8.1, <1.10; torchvision>=0.9.1; scikit-learn>=0.23.0; tiledb-cloud>=0.7.11
 
-[tool:pytest]
-addopts = --cov=tiledb --cov-report=term-missing
-
 [aliases]
 test=pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import multiprocessing
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def ensure_multiprocessing_spawn():
+    if multiprocessing.get_start_method(allow_none=True) != "spawn":
+        multiprocessing.set_start_method("spawn")


### PR DESCRIPTION
Minor test tweaks and improvements, mainly for local execution
 
- Ensure that the `multiprocessing` start method is 'spawn' instead of 'fork' (default on unix systems) to avoid [deadlocks in TileDB](https://github.com/TileDB-Inc/TileDB-Py/issues/654). 
- Run tests in parallel on many/all cores with [pytest-xdist](https://github.com/pytest-dev/pytest-xdist).