### PR TITLE
Tooling & test improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,15 @@ jobs:
     - name: 'Run tests'
       if: ${{ matrix.os != 'macos-latest' || matrix.python-version != '3.7' }}
       run: |
-        pip install pytest-mock pytest-xdist
-        pytest -n auto tests/
+        pip install pytest-mock
+        pytest tests/
 
     - name: 'Run test coverage statistics'
       id: stats
       if: ${{ matrix.os == 'macos-latest' && matrix.python-version == '3.7' }}
       run: |
-        pip install pytest-mock pytest-xdist pytest-cov
-        TEST_COVERAGE="$(pytest -n auto --cov-report=term-missing --cov=tiledb tests/ | grep '^TOTAL' | awk -v N=4 '{print $N}')"
+        pip install pytest-mock pytest-cov
+        TEST_COVERAGE="$(pytest --cov-report=term-missing --cov=tiledb tests/ | grep '^TOTAL' | awk -v N=4 '{print $N}')"
         echo "::set-output name=COVERAGE::$TEST_COVERAGE"
 
     - name: 'Create Test Coverage Badge'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,21 +30,21 @@ jobs:
         rm -rf mypyenv
 
     - name: 'Run tests'
-      if: ${{ matrix.os != 'macos-latest' || matrix.python-version != '3.7' }}
+      if: ${{ matrix.os != 'ubuntu-latest' || matrix.python-version != '3.7' }}
       run: |
         pip install pytest-mock
         pytest tests/
 
     - name: 'Run test coverage statistics'
       id: stats
-      if: ${{ matrix.os == 'macos-latest' && matrix.python-version == '3.7' }}
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' }}
       run: |
         pip install pytest-mock pytest-cov
         TEST_COVERAGE="$(pytest --cov-report=term-missing --cov=tiledb tests/ | grep '^TOTAL' | awk -v N=4 '{print $N}')"
         echo "::set-output name=COVERAGE::$TEST_COVERAGE"
 
     - name: 'Create Test Coverage Badge'
-      if: ${{ matrix.os == 'macos-latest' && matrix.python-version == '3.7' }}
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' }}
       uses: psf/black@21.7b0
       with:
         auth: ${{ secrets.COVERAGE_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,10 @@ jobs:
 
     - name: 'Run mypy'
       run: |
-        pip install mypy
-        mypy .
+        python -m venv mypyenv
+        mypyenv/bin/pip install mypy
+        mypyenv/bin/mypy .
+        rm -rf mypyenv
 
     - name: 'Run tests'
       if: ${{ matrix.os != 'macos-latest' || matrix.python-version != '3.7' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 21.9b0
+    rev: 22.1.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
@@ -8,12 +8,11 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.9.3
+    rev: 5.10.1
     hooks:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.931
     hooks:
       - id: mypy
-        additional_dependencies: [torch>=1.8.1]

--- a/examples/cloud/serverless_training/pytorch/model_load_and_predict.py
+++ b/examples/cloud/serverless_training/pytorch/model_load_and_predict.py
@@ -33,7 +33,7 @@ def predict() -> List[int]:
 
     class Net(nn.Module):
         def __init__(self, shape: Tuple[int, int]):
-            super().__init__()  # type: ignore
+            super().__init__()
             self.flatten = nn.Flatten()
             self.linear_relu_stack = nn.Sequential(
                 nn.Linear(np.product(shape), 32),
@@ -58,7 +58,7 @@ def predict() -> List[int]:
     )
 
     with tiledb.open(IMAGES_URI) as x, tiledb.open(LABELS_URI) as y:
-        with torch.no_grad():  # type: ignore
+        with torch.no_grad():
             tiledb_dataset = PyTorchTileDBDenseDataset(
                 x_array=x, y_array=y, batch_size=IO_BATCH_SIZE
             )

--- a/examples/cloud/serverless_training/pytorch/model_training.py
+++ b/examples/cloud/serverless_training/pytorch/model_training.py
@@ -33,7 +33,7 @@ def train() -> None:
 
     class Net(nn.Module):
         def __init__(self, shape: Tuple[int, int]):
-            super().__init__()  # type: ignore
+            super().__init__()
             self.flatten = nn.Flatten()
             self.linear_relu_stack = nn.Sequential(
                 nn.Linear(np.product(shape), 32),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 import multiprocessing
+import os
 
 import pytest
 
 
 @pytest.fixture(autouse=True, scope="session")
-def ensure_multiprocessing_spawn():
-    if multiprocessing.get_start_method(allow_none=True) != "spawn":
-        multiprocessing.set_start_method("spawn")
+def set_multiprocessing_start_method():
+    if os.name == "posix":
+        multiprocessing.set_start_method("forkserver")

--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -88,7 +88,7 @@ class PyTorchTileDBDenseDataset(torch.utils.data.IterableDataset[DataType]):
             raise ValueError("Buffer size should be geq to the batch size.")
 
     def __iter__(self) -> Iterator[DataType]:
-        worker_info = torch.utils.data.get_worker_info()  # type: ignore
+        worker_info = torch.utils.data.get_worker_info()
 
         # Get number of observations
         rows = self.x.schema.domain.shape[0]

--- a/tiledb/ml/readers/pytorch_sparse.py
+++ b/tiledb/ml/readers/pytorch_sparse.py
@@ -140,7 +140,7 @@ class PyTorchTileDBSparseDataset(torch.utils.data.IterableDataset[DataType]):
         return buffer_csr
 
     def __iter__(self) -> Iterator[DataType]:
-        worker_info = torch.utils.data.get_worker_info()  # type: ignore
+        worker_info = torch.utils.data.get_worker_info()
 
         # Get number of observations
         rows = self.x.schema.domain.shape[0]


### PR DESCRIPTION
Follow up to #94:
- Revert parallel test execution on CI: GH action runners have only 2-3 cores and running tests in parallel turns out to be slower.
- Set multiprocessing start method to `forkserver`: faster than `spawn`(especially on macos) and safer than `fork`.
- Run test coverage on ubuntu-latest instead of macos-latest; generally macos runners are slower on GH actions.
- Update pre-commit hooks