### PR TITLE
Fix deprecation warning for attrs with var=True and fixed len dtype

### DIFF
--- a/tiledb/ml/models/pytorch.py
+++ b/tiledb/ml/models/pytorch.py
@@ -156,7 +156,7 @@ class PyTorchTileDBModel(TileDBModel[torch.nn.Module]):
         attrs.append(
             tiledb.Attr(
                 name="model_state_dict",
-                dtype="S1",
+                dtype=bytes,
                 var=True,
                 filters=tiledb.FilterList([tiledb.ZstdFilter()]),
                 ctx=self.ctx,
@@ -168,7 +168,7 @@ class PyTorchTileDBModel(TileDBModel[torch.nn.Module]):
             attrs.append(
                 tiledb.Attr(
                     name="optimizer_state_dict",
-                    dtype="S1",
+                    dtype=bytes,
                     var=True,
                     filters=tiledb.FilterList([tiledb.ZstdFilter()]),
                     ctx=self.ctx,
@@ -181,7 +181,7 @@ class PyTorchTileDBModel(TileDBModel[torch.nn.Module]):
                 attrs.append(
                     tiledb.Attr(
                         name=key,
-                        dtype="S1",
+                        dtype=bytes,
                         var=True,
                         filters=tiledb.FilterList([tiledb.ZstdFilter()]),
                         ctx=self.ctx,

--- a/tiledb/ml/models/sklearn.py
+++ b/tiledb/ml/models/sklearn.py
@@ -80,7 +80,7 @@ class SklearnTileDBModel(TileDBModel[BaseEstimator]):
         attrs = [
             tiledb.Attr(
                 name="model_params",
-                dtype="S1",
+                dtype=bytes,
                 var=True,
                 filters=tiledb.FilterList([tiledb.ZstdFilter()]),
                 ctx=self.ctx,

--- a/tiledb/ml/models/tensorflow_keras.py
+++ b/tiledb/ml/models/tensorflow_keras.py
@@ -186,14 +186,14 @@ class TensorflowKerasTileDBModel(TileDBModel[tf.keras.Model]):
             attrs = [
                 tiledb.Attr(
                     name="model_weights",
-                    dtype="S1",
+                    dtype=bytes,
                     var=True,
                     filters=tiledb.FilterList([tiledb.ZstdFilter()]),
                     ctx=self.ctx,
                 ),
                 tiledb.Attr(
                     name="optimizer_weights",
-                    dtype="S1",
+                    dtype=bytes,
                     var=True,
                     filters=tiledb.FilterList([tiledb.ZstdFilter()]),
                     ctx=self.ctx,
@@ -204,7 +204,7 @@ class TensorflowKerasTileDBModel(TileDBModel[tf.keras.Model]):
                 # String names of weights of each layer of the model
                 tiledb.Attr(
                     name="weight_names",
-                    dtype="S1",
+                    dtype=bytes,
                     var=True,
                     filters=tiledb.FilterList([tiledb.ZstdFilter()]),
                     ctx=self.ctx,
@@ -212,7 +212,7 @@ class TensorflowKerasTileDBModel(TileDBModel[tf.keras.Model]):
                 # The values of weights of each layer of the model
                 tiledb.Attr(
                     name="weight_values",
-                    dtype="S1",
+                    dtype=bytes,
                     var=True,
                     filters=tiledb.FilterList([tiledb.ZstdFilter()]),
                     ctx=self.ctx,
@@ -220,7 +220,7 @@ class TensorflowKerasTileDBModel(TileDBModel[tf.keras.Model]):
                 # Layer names TF format of the saved/loaded model
                 tiledb.Attr(
                     name="layer_name",
-                    dtype="U1",
+                    dtype=str,
                     var=True,
                     filters=tiledb.FilterList([tiledb.ZstdFilter()]),
                     ctx=self.ctx,
@@ -228,7 +228,7 @@ class TensorflowKerasTileDBModel(TileDBModel[tf.keras.Model]):
                 # The weight values of the optimizer in case the model is saved compiled
                 tiledb.Attr(
                     name="optimizer_weights",
-                    dtype="S1",
+                    dtype=bytes,
                     var=True,
                     filters=tiledb.FilterList([tiledb.ZstdFilter()]),
                     ctx=self.ctx,


### PR DESCRIPTION
Fixes ```DeprecationWarning: Attr given `var=True` but `dtype` `|S1` is fixed; setting `dtype=S0`. Hint: set `var=True` with `dtype=S0`, or `var=False`with `dtype=|S1` ```