### PR TITLE
Fix max workers to 2

### DIFF
--- a/tiledb/ml/readers/_tensorflow_generators.py
+++ b/tiledb/ml/readers/_tensorflow_generators.py
@@ -201,7 +201,7 @@ def sparse_dense_generator(
     x_shape = x_array.schema.domain.shape[1:]
 
     # https://github.com/tensorflow/tensorflow/issues/44565
-    with ThreadPoolExecutor(max_workers=1) as executor:
+    with ThreadPoolExecutor(max_workers=2) as executor:
         for offset in offsets:
             x_buffer, y_buffer = executor.map(
                 lambda array: array[offset : offset + buffer_size],  # type: ignore


### PR DESCRIPTION
Small hot-fix of the number of `max_workers` from 1 to 2 in `_tensorflow_generators.py`