### PR TITLE
Data loading for (dense, x sparse y) 

### DIFF
--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -50,10 +50,11 @@ class PyTorchTileDBDataset(torch.utils.data.IterableDataset[Sequence[torch.Tenso
         kwargs = self._generator_kwargs.copy()
         worker_info = torch.utils.data.get_worker_info()
         if worker_info is not None:
-            if isinstance(kwargs["x_array"], tiledb.SparseArray):
-                raise NotImplementedError(
-                    "https://github.com/pytorch/pytorch/issues/20248"
-                )
+            for array_key in "x_array", "y_array":
+                if isinstance(kwargs[array_key], tiledb.SparseArray):
+                    raise NotImplementedError(
+                        "https://github.com/pytorch/pytorch/issues/20248"
+                    )
             per_worker = int(math.ceil(self._rows / worker_info.num_workers))
             start_offset = worker_info.id * per_worker
             stop_offset = min(start_offset + per_worker, self._rows)

--- a/tiledb/ml/readers/tensorflow.py
+++ b/tiledb/ml/readers/tensorflow.py
@@ -41,10 +41,6 @@ def TensorflowTileDBDataset(
     :param batch_shuffle: True for shuffling batches.
     :param within_batch_shuffle: True for shuffling records in each batch.
     """
-    if isinstance(x_array, tiledb.DenseArray):
-        if isinstance(y_array, tiledb.SparseArray):
-            raise TypeError("Dense x_array and sparse y_array not currently supported")
-
     # Check that x_array and y_array have the same number of rows
     rows: int = x_array.shape[0]
     if rows != y_array.shape[0]:


### PR DESCRIPTION
The dense dataset classes (`TensorflowTileDBDenseDataset`, `PyTorchTileDBDenseDataset`) expected both x and y arrays to be dense but actually ensured this only for x, leaving unspecifed what happens for the (dense x, sparse y) case. This has not been (properly) addressed by the recent code and test refactorings.

This PR adds related tests and clarifies the situation as follows:
- Not currently supported if `within_batch_shuffle=True`; `NotImplementedError` is raised.
- Not currently supported on PyTorch for multi-process data loading due to pytorch/pytorch#20248.
- Supported in all other cases.