### PR TITLE
Fix BaseSparseBatch.set_buffer_offset

### DIFF
--- a/tests/readers/test_pytorch.py
+++ b/tests/readers/test_pytorch.py
@@ -169,7 +169,7 @@ class TestPyTorchTileDBDataset:
         within_batch_shuffle,
     ):
         x_data = rand_array(num_rows, *x_shape, sparse=x_sparse)
-        x_data[np.nonzero(x_data[0])] = 0
+        x_data[np.random.randint(len(x_data))] = 0
         with ingest_in_tiledb(
             tmpdir,
             x_data=x_data,
@@ -184,6 +184,7 @@ class TestPyTorchTileDBDataset:
             within_batch_shuffle=within_batch_shuffle,
         ) as dataset_kwargs:
             dataset = PyTorchTileDBDataset(**dataset_kwargs)
-            with pytest.raises(Exception):
+            with pytest.raises(ValueError) as ex:
                 for _ in dataset:
                     pass
+            assert "x and y batches should have the same length" in str(ex.value)

--- a/tests/readers/test_tensorflow.py
+++ b/tests/readers/test_tensorflow.py
@@ -166,7 +166,7 @@ class TestTensorflowTileDBDataset:
         within_batch_shuffle,
     ):
         x_data = rand_array(num_rows, *x_shape, sparse=x_sparse)
-        x_data[np.nonzero(x_data[0])] = 0
+        x_data[np.random.randint(len(x_data))] = 0
         with ingest_in_tiledb(
             tmpdir,
             x_data=x_data,
@@ -181,6 +181,7 @@ class TestTensorflowTileDBDataset:
             within_batch_shuffle=within_batch_shuffle,
         ) as dataset_kwargs:
             dataset = TensorflowTileDBDataset(**dataset_kwargs)
-            with pytest.raises(Exception):
+            with pytest.raises(tf.errors.InvalidArgumentError) as ex:
                 for _ in dataset:
                     pass
+            assert "x and y batches should have the same length" in str(ex.value)

--- a/tiledb/ml/readers/_batch_utils.py
+++ b/tiledb/ml/readers/_batch_utils.py
@@ -110,12 +110,7 @@ class BaseSparseBatch(BaseBatch[Tensor]):
         # Normalize indices: We want the coords indices to be in the [0, batch_size]
         # range. If we do not normalize the sparse tensor is being created but with a
         # dimension [0, max(coord_index)], which is overkill
-        row_size_norm = row.max() - row.min() + 1
-        col_size_norm = col.max() + 1
-        self._buffer_csr = sp.csr_matrix(
-            (buffer[self._attrs[0]], (row - offset, col)),
-            shape=(row_size_norm, col_size_norm),
-        )
+        self._buffer_csr = sp.csr_matrix((buffer[self._attrs[0]], (row - offset, col)))
 
     def set_batch_slice(self, batch_slice: slice) -> None:
         assert hasattr(self, "_buffer_csr"), "set_buffer_offset() not called"
@@ -227,9 +222,8 @@ def tensor_generator(
                 y_batch.set_batch_slice(batch_slice)
                 if len(x_batch) != len(y_batch):
                     raise ValueError(
-                        "x_array and y_array should have the same number of rows, "
-                        "i.e. the first dimension of x_array and y_array should be "
-                        "of equal domain extent inside the batch"
+                        "x and y batches should have the same length: "
+                        f"len(x_batch)={len(x_batch)}, len(y_batch)={len(y_batch)}"
                     )
                 if x_batch:
                     if within_batch_shuffle:


### PR DESCRIPTION
`BaseSparseBatch.set_buffer_offset` may raise `ValueError: row index exceeds matrix dimensions` when it [creates the sparse matrix](https://github.com/TileDB-Inc/TileDB-ML/blob/d5893901667b2b14fe881c314e03a8a90641b1e6/tiledb/ml/readers/_batch_utils.py#L115). Apparently the passed `shape=(row.max() - row.min() + 1,  col.max() + 1)` is not always correct. The shape parameter in [scipy.sparse.csr_matrix](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html#scipy-sparse-csr-matrix) is optional so we can just omit it and let it be determined automatically.

The reason this was not caught by the tests was that it was masked by an overly general ` with pytest.raises(Exception)`. This PR also updates the tests to expect only the exception raised when [`len(x_batch) != len(y_batch)`](https://github.com/TileDB-Inc/TileDB-ML/blob/master/tiledb/ml/readers/_batch_utils.py#L231).