### PR TITLE
Adding unit tests for read sparse order when batch_shuffle=False

### DIFF
--- a/tests/readers/test_tensorflow.py
+++ b/tests/readers/test_tensorflow.py
@@ -17,6 +17,7 @@ from .utils import (
     ingest_in_tiledb,
     parametrize_for_dataset,
     rand_array,
+    tensor_values,
     validate_tensor_generator,
 )
 
@@ -148,6 +149,44 @@ class TestTensorflowTileDBDataset:
             with pytest.raises(ValueError) as ex:
                 TensorflowTileDBDataset(**dataset_kwargs)
             assert "X and Y arrays must have the same number of rows" in str(ex.value)
+
+    @parametrize_for_dataset(x_sparse=(True,), batch_shuffle=(False,))
+    def test_sparse_read_order(
+        self,
+        tmpdir,
+        num_rows,
+        x_sparse,
+        y_sparse,
+        x_shape,
+        y_shape,
+        num_attrs,
+        pass_attrs,
+        batch_size,
+        buffer_size,
+        batch_shuffle,
+        within_batch_shuffle,
+    ):
+        x_array = rand_array(num_rows, *x_shape, sparse=x_sparse)
+        with ingest_in_tiledb(
+            tmpdir,
+            # Add one extra row on X
+            x_data=x_array,
+            y_data=rand_array(num_rows, *y_shape, sparse=y_sparse),
+            x_sparse=x_sparse,
+            y_sparse=y_sparse,
+            batch_size=batch_size,
+            num_attrs=num_attrs,
+            pass_attrs=pass_attrs,
+            buffer_size=buffer_size,
+            batch_shuffle=batch_shuffle,
+            within_batch_shuffle=within_batch_shuffle,
+        ) as dataset_kwargs:
+            dataset = TensorflowTileDBDataset(**dataset_kwargs)
+            dataset_val = [
+                value for batch in dataset for value in tensor_values(batch[0])
+            ]
+            # default tolerance is ± 2.3e-06
+            assert x_array[np.nonzero(x_array)].tolist() == pytest.approx(dataset_val)
 
     @parametrize_for_dataset(x_sparse=[True])
     def test_x_sparse_unequal_num_rows_in_batch(

--- a/tests/readers/test_tensorflow.py
+++ b/tests/readers/test_tensorflow.py
@@ -17,7 +17,6 @@ from .utils import (
     ingest_in_tiledb,
     parametrize_for_dataset,
     rand_array,
-    tensor_values,
     validate_tensor_generator,
 )
 
@@ -150,44 +149,6 @@ class TestTensorflowTileDBDataset:
                 TensorflowTileDBDataset(**dataset_kwargs)
             assert "X and Y arrays must have the same number of rows" in str(ex.value)
 
-    @parametrize_for_dataset(x_sparse=(True,), batch_shuffle=(False,))
-    def test_sparse_read_order(
-        self,
-        tmpdir,
-        num_rows,
-        x_sparse,
-        y_sparse,
-        x_shape,
-        y_shape,
-        num_attrs,
-        pass_attrs,
-        batch_size,
-        buffer_size,
-        batch_shuffle,
-        within_batch_shuffle,
-    ):
-        x_array = rand_array(num_rows, *x_shape, sparse=x_sparse)
-        with ingest_in_tiledb(
-            tmpdir,
-            # Add one extra row on X
-            x_data=x_array,
-            y_data=rand_array(num_rows, *y_shape, sparse=y_sparse),
-            x_sparse=x_sparse,
-            y_sparse=y_sparse,
-            batch_size=batch_size,
-            num_attrs=num_attrs,
-            pass_attrs=pass_attrs,
-            buffer_size=buffer_size,
-            batch_shuffle=batch_shuffle,
-            within_batch_shuffle=within_batch_shuffle,
-        ) as dataset_kwargs:
-            dataset = TensorflowTileDBDataset(**dataset_kwargs)
-            dataset_val = [
-                value for batch in dataset for value in tensor_values(batch[0])
-            ]
-            # default tolerance is ± 2.3e-06
-            assert x_array[np.nonzero(x_array)].tolist() == pytest.approx(dataset_val)
-
     @parametrize_for_dataset(x_sparse=[True])
     def test_x_sparse_unequal_num_rows_in_batch(
         self,
@@ -224,3 +185,42 @@ class TestTensorflowTileDBDataset:
                 for _ in dataset:
                     pass
             assert "x and y batches should have the same length" in str(ex.value)
+
+    @parametrize_for_dataset(x_sparse=[True], batch_shuffle=[False])
+    def test_sparse_read_order(
+        self,
+        tmpdir,
+        num_rows,
+        x_sparse,
+        y_sparse,
+        x_shape,
+        y_shape,
+        num_attrs,
+        pass_attrs,
+        batch_size,
+        buffer_size,
+        batch_shuffle,
+        within_batch_shuffle,
+    ):
+        x_data = rand_array(num_rows, *x_shape, sparse=x_sparse)
+        with ingest_in_tiledb(
+            tmpdir,
+            x_data=x_data,
+            y_data=rand_array(num_rows, *y_shape, sparse=y_sparse),
+            x_sparse=x_sparse,
+            y_sparse=y_sparse,
+            batch_size=batch_size,
+            num_attrs=num_attrs,
+            pass_attrs=pass_attrs,
+            buffer_size=buffer_size,
+            batch_shuffle=batch_shuffle,
+            within_batch_shuffle=within_batch_shuffle,
+        ) as dataset_kwargs:
+            dataset = TensorflowTileDBDataset(**dataset_kwargs)
+            generated_x_data = np.concatenate(
+                [
+                    tf.sparse.to_dense(tf.sparse.reorder(tensors[0]))
+                    for tensors in dataset
+                ]
+            )
+            np.testing.assert_array_almost_equal(generated_x_data, x_data)

--- a/tests/readers/utils.py
+++ b/tests/readers/utils.py
@@ -181,3 +181,12 @@ def _is_sparse_tensor(tensor):
     if isinstance(tensor, tf.Tensor):
         return False
     assert False, f"Unknown tensor type: {type(tensor)}"
+
+
+def tensor_values(tensor):
+    if isinstance(tensor, tf.SparseTensor):
+        return [value.numpy().tolist() for value in tensor.values]
+    if isinstance(tensor, torch.Tensor):
+        return [value.numpy().tolist() for value in tensor._values()]
+
+    assert False, f"Unknown tensor type: {type(tensor)}"

--- a/tests/readers/utils.py
+++ b/tests/readers/utils.py
@@ -181,12 +181,3 @@ def _is_sparse_tensor(tensor):
     if isinstance(tensor, tf.Tensor):
         return False
     assert False, f"Unknown tensor type: {type(tensor)}"
-
-
-def tensor_values(tensor):
-    if isinstance(tensor, tf.SparseTensor):
-        return [value.numpy().tolist() for value in tensor.values]
-    if isinstance(tensor, torch.Tensor):
-        return [value.numpy().tolist() for value in tensor._values()]
-
-    assert False, f"Unknown tensor type: {type(tensor)}"

--- a/tests/readers/utils.py
+++ b/tests/readers/utils.py
@@ -107,7 +107,7 @@ def _ingest_in_tiledb(
         tiledb.Dim(
             name=f"dim_{dim}",
             domain=(0, data.shape[dim] - 1),
-            tile=data.shape[dim] if dim > 0 else batch_size,
+            tile=np.random.randint(1, data.shape[dim] if dim > 0 else batch_size),
             dtype=np.int32,
         )
         for dim in range(data.ndim)


### PR DESCRIPTION
This PR addresses sparse array reads and specifically batch generation. 
Investigated if un-ordered sparse layout reads lead `batch_shuffle` argument to be semantically always `True`.

Unit tests are added for both `TF` and `Pytorch`
The comparison between the array given to the API and the output of generator showed no difference. ~Comparison is made on the values of the array and not indices as these are dependent on the `buffer_size`~
