### PR TITLE
Return correctly sized sparse tensors

### DIFF
--- a/tests/readers/utils.py
+++ b/tests/readers/utils.py
@@ -168,14 +168,9 @@ def validate_tensor_generator(
 def _validate_tensor(tensor, batch_size, expected_sparse, expected_shape):
     num_rows, *row_shape = tensor.shape
     assert row_shape == list(expected_shape)
-    if expected_sparse:
-        assert _is_sparse_tensor(tensor)
-        # for sparse tensors, num_rows should be equal to batch_size
-        assert num_rows == batch_size
-    else:
-        assert not _is_sparse_tensor(tensor)
-        # for dense tensors, num_rows may be less than batch_size
-        assert num_rows <= batch_size
+    assert _is_sparse_tensor(tensor) == expected_sparse
+    # num_rows may be less than batch_size
+    assert num_rows <= batch_size
 
 
 def _is_sparse_tensor(tensor):


### PR DESCRIPTION
The sparse dataset loaders currently yield sparse tensors of fixed `batch_size` length. For example with `buffer_size=50` and `batch_size=32`, the last batch of each buffer will have size of 32 instead of `50-32=18` as it would if it was dense, with the last `32-18=14` rows being all zeros.

https://github.com/TileDB-Inc/TileDB-ML/commit/ef832c2cb7f83f06466b277efbea1e7e8c609bec aligns `BaseSparseBatch.iter_tensors` to the respective `BaseDenseBatch` method by determining the (dense) shape of each batch instead of forcing the same shape for all batches.

https://github.com/TileDB-Inc/TileDB-ML/commit/8d03c29c948e82e1578c2fb98e301fc3f58f7979 is an unrelated enhancement for creating and caching a `tiledb.Query` instance once instead of doing it on every `read_buffer` call.
