### PR TITLE
Better default buffer_size for dense arrays

### DIFF
--- a/tests/readers/test_batch_utils.py
+++ b/tests/readers/test_batch_utils.py
@@ -4,8 +4,8 @@ import pytest
 import tiledb
 from tiledb.ml.readers._batch_utils import (
     estimate_row_bytes,
-    get_num_batches,
     iter_batches,
+    normalize_buffer_size,
 )
 
 
@@ -81,18 +81,6 @@ def test_estimate_row_bytes_dense(dense_uri):
         assert estimate_row_bytes(a, attrs=["af4"]) == 40
 
 
-def test_get_num_batches_dense(dense_uri):
-    batch_size = 16
-    buffer_bytes = 50000
-    with tiledb.open(dense_uri) as a:
-        # int(50000 / 16 / 130) == 24
-        assert get_num_batches(batch_size, buffer_bytes, a) == 24
-        # int(50000 / 16 / 90) == 34
-        assert get_num_batches(batch_size, buffer_bytes, a, attrs=["af8", "au1"]) == 34
-        # int(50000 / 16 / 40) == 78 but there are at most ceil(1000 / 16) == 63 batches
-        assert get_num_batches(batch_size, buffer_bytes, a, attrs=["af4"]) == 63
-
-
 def test_estimate_row_bytes_sparse(sparse_uri):
     with tiledb.open(sparse_uri) as a:
         # 3 cells/row, 3*4 bytes for dims + 8+4+1=13 bytes for attrs = 25 bytes/cell
@@ -103,16 +91,26 @@ def test_estimate_row_bytes_sparse(sparse_uri):
         assert estimate_row_bytes(a, attrs=["af4"]) == 48
 
 
-def test_get_num_batches_sparse(sparse_uri):
+def test_normalize_buffer_size():
     batch_size = 16
-    buffer_bytes = 50000
-    with tiledb.open(sparse_uri) as a:
-        # int(50000 / 16 / 75) == 41
-        assert get_num_batches(batch_size, buffer_bytes, a) == 41
-        # int(50000 / 16 / 63) == 49
-        assert get_num_batches(batch_size, buffer_bytes, a, attrs=["af8", "au1"]) == 49
-        # int(50000 / 16 / 48) == 65 but there are at most ceil(1000 / 16) == 63 batches
-        assert get_num_batches(batch_size, buffer_bytes, a, attrs=["af4"]) == 63
+
+    array_size = 48
+    for buffer_size in range(1, 32):
+        assert normalize_buffer_size(buffer_size, batch_size, array_size) == 16
+    for buffer_size in range(32, 48):
+        assert normalize_buffer_size(buffer_size, batch_size, array_size) == 32
+    for buffer_size in range(48, 1000):
+        assert normalize_buffer_size(buffer_size, batch_size, array_size) == 48
+
+    array_size = 53
+    for buffer_size in range(1, 32):
+        assert normalize_buffer_size(buffer_size, batch_size, array_size) == 16
+    for buffer_size in range(32, 48):
+        assert normalize_buffer_size(buffer_size, batch_size, array_size) == 32
+    for buffer_size in range(48, 53):
+        assert normalize_buffer_size(buffer_size, batch_size, array_size) == 48
+    for buffer_size in range(53, 1000):
+        assert normalize_buffer_size(buffer_size, batch_size, array_size) == 64
 
 
 def test_iter_batches():

--- a/tests/readers/test_batch_utils.py
+++ b/tests/readers/test_batch_utils.py
@@ -4,6 +4,7 @@ import pytest
 import tiledb
 from tiledb.ml.readers._batch_utils import (
     estimate_row_bytes,
+    get_max_buffer_size,
     iter_batches,
     normalize_buffer_size,
 )
@@ -15,9 +16,9 @@ def dense_uri(tmp_path):
     schema = tiledb.ArraySchema(
         sparse=False,
         domain=tiledb.Domain(
-            tiledb.Dim(name="d0", domain=(0, 999), dtype=np.uint32),
-            tiledb.Dim(name="d1", domain=(1, 5), dtype=np.uint32),
-            tiledb.Dim(name="d2", domain=(1, 2), dtype=np.uint32),
+            tiledb.Dim(name="d0", domain=(0, 9999), dtype=np.uint32, tile=123),
+            tiledb.Dim(name="d1", domain=(1, 5), dtype=np.uint32, tile=2),
+            tiledb.Dim(name="d2", domain=(1, 2), dtype=np.uint32, tile=1),
         ),
         attrs=[
             tiledb.Attr(name="af8", dtype=np.float64),
@@ -138,3 +139,31 @@ def test_iter_batches():
         "Batch(x[16:24], y[40:48])",
         "Batch(x[24:25], y[48:49])",
     ]
+
+
+@pytest.mark.parametrize("memory_budget", [2**i for i in range(14, 20)])
+@pytest.mark.parametrize(
+    "attrs",
+    [(), ("af8",), ("af4",), ("au1",), ("af8", "af4"), ("af8", "au1"), ("af4", "au1")],
+)
+def test_get_max_buffer_size(dense_uri, memory_budget, attrs):
+    config = {
+        "sm.memory_budget": memory_budget,
+        "py.max_incomplete_retries": 0,
+    }
+    with tiledb.scope_ctx(config), tiledb.open(dense_uri) as a:
+        buffer_size = get_max_buffer_size(a.schema, attrs)
+        # Check that the buffer size is a multiple of the row tile extent
+        assert buffer_size % a.dim(0).tile == 0
+
+        # Check that we can slice with buffer_size without incomplete reads
+        query = a.query(attrs=attrs or None)
+        for offset in range(0, a.shape[0], buffer_size):
+            query[offset : offset + buffer_size]
+
+        if buffer_size < a.shape[0]:
+            # Check that buffer_size is the max size we can slice without incomplete reads
+            buffer_size += 1
+            with pytest.raises(tiledb.TileDBError):
+                for offset in range(0, a.shape[0], buffer_size):
+                    query[offset : offset + buffer_size]

--- a/tiledb/ml/readers/_batch_utils.py
+++ b/tiledb/ml/readers/_batch_utils.py
@@ -180,11 +180,14 @@ def tensor_generator(
         Tuple[int, DenseTileDBTensorGenerator[DenseTensor]],
         Tuple[int, SparseTileDBTensorGenerator[SparseTensor]],
     ]:
-        if buffer_bytes is None:
-            buffer_size = batch_size
-        else:
+        if buffer_bytes is not None:
             est_row_bytes = estimate_row_bytes(array, attrs, start_offset, stop_offset)
             buffer_size = buffer_bytes // est_row_bytes
+        elif not array.schema.sparse:
+            buffer_size = get_max_buffer_size(array.schema, attrs)
+        else:
+            # TODO
+            buffer_size = batch_size
         buffer_size = normalize_buffer_size(
             buffer_size, batch_size, stop_offset - start_offset
         )
@@ -401,3 +404,57 @@ def normalize_buffer_size(buffer_size: int, batch_size: int, array_size: int) ->
     else:
         num_batches = ceil(array_size / batch_size)
     return num_batches * batch_size
+
+
+def get_max_buffer_size(
+    schema: tiledb.ArraySchema,
+    attrs: Sequence[str] = (),
+    memory_budget: Optional[int] = None,
+) -> int:
+    """
+    Get the maximum number of "rows" that can be read from an array with the given schema
+    without incurring incomplete reads.
+
+    A "row" is a slice with the first dimension fixed.
+
+    :param schema: The array schema.
+    :param attrs: The attributes to read; defaults to all array attributes.
+    :param memory_budget: The maximum amount of memory to use. If not given, it is
+        determined from `tiledb.default_ctx().config()["sm.memory_budget"]`
+    """
+    if schema.sparse:
+        raise NotImplementedError(
+            "get_max_buffer_size() is not implemented for sparse arrays"
+        )
+
+    if memory_budget is None:
+        memory_budget = int(tiledb.default_ctx().config()["sm.memory_budget"])
+
+    # The memory budget should be large enough to read the cells of the largest attribute
+    if not attrs:
+        attrs = get_attr_names(schema)
+    bytes_per_cell = max(schema.attr(attr).dtype.itemsize for attr in attrs)
+
+    # We want to be reading tiles following the tile extents along each dimension.
+    # The number of cells for each such tile is the product of all tile extents.
+    dim_tiles = tuple(int(schema.domain.dim(idx).tile) for idx in range(schema.ndim))
+    cells_per_tile = np.prod(dim_tiles)
+
+    # Reading a slice of dim_tiles[0] rows requires reading a number of tiles that
+    # depends on the size and tile extent of each dimension after the first one.
+    assert len(schema.shape) == len(dim_tiles)
+    tiles_per_slice = np.prod(
+        tuple(
+            ceil(dim_size / dim_tile)
+            for dim_size, dim_tile in zip(schema.shape[1:], dim_tiles[1:])
+        )
+    )
+
+    # Compute the size in bytes of each slice of dim_tiles[0] rows
+    bytes_per_slice = int(bytes_per_cell * cells_per_tile * tiles_per_slice)
+
+    # Compute the number of slices that fit within the memory budget
+    num_slices = memory_budget // bytes_per_slice
+
+    # Compute the total number of rows to slice
+    return dim_tiles[0] * num_slices


### PR DESCRIPTION
Currently `buffer_size` defaults to `batch_size` if no `buffer_bytes` parameter is specified by the user. Since `batch_size` is typically small (e.g. 32 or 64), this leads to submitting many small queries to TileDB, which is suboptimal.

This PR introduces `get_max_buffer_size()` that determines the maximum buffer size that can be used without causing incomplete reads for a given memory budget (as specified by the `sm.memory_budget` parameter in the TileDB [configuration](https://docs.tiledb.com/main/how-to/configuration)). This is based on the assumption (supported by experimental validation) that the larger the buffer slice, the better performance is, at least for dense arrays and as long as the buffer fits within the allowed memory budget so that it doesn't trigger incomplete reads.