### PR TITLE
Use get_max_buffer_size() for dense arrays even when buffer_bytes is specified

### DIFF
--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -33,8 +33,8 @@ class PyTorchTileDBDataset(torch.utils.data.IterableDataset[Sequence[torch.Tenso
         :param x_array: TileDB array of the features.
         :param y_array: TileDB array of the labels.
         :param batch_size: Size of each batch.
-        :param buffer_bytes: Size (in bytes) of the buffer used to read from each array.
-            If not given, it is determined automatically.
+        :param buffer_bytes: Maximum size (in bytes) of memory to allocate for reading
+            from each array (default=`tiledb.default_ctx().config()["sm.memory_budget"]`).
         :param shuffle: True for shuffling rows.
         :param x_attrs: Attribute names of x_array.
         :param y_attrs: Attribute names of y_array.

--- a/tiledb/ml/readers/tensorflow.py
+++ b/tiledb/ml/readers/tensorflow.py
@@ -35,8 +35,8 @@ def TensorflowTileDBDataset(
     :param x_array: TileDB array of the features.
     :param y_array: TileDB array of the labels.
     :param batch_size: Size of each batch.
-    :param buffer_bytes: Size (in bytes) of the buffer used to read from each array.
-        If not given, it is determined automatically.
+    :param buffer_bytes: Maximum size (in bytes) of memory to allocate for reading from
+        each array (default=`tiledb.default_ctx().config()["sm.memory_budget"]`).
     :param shuffle: True for shuffling rows.
     :param x_attrs: Attribute names of x_array.
     :param y_attrs: Attribute names of y_array.


### PR DESCRIPTION
As suggested [here](https://github.com/TileDB-Inc/TileDB-ML/pull/121#pullrequestreview-912968735).