### PR TITLE
Convert numpy arrays to dense tensors implicitly

### DIFF
--- a/tests/readers/test_tensorflow.py
+++ b/tests/readers/test_tensorflow.py
@@ -8,7 +8,6 @@ import tensorflow as tf
 
 from tiledb.ml.readers._batch_utils import tensor_generator
 from tiledb.ml.readers.tensorflow import (
-    TensorflowDenseTileDBTensorGenerator,
     TensorflowSparseTileDBTensorGenerator,
     TensorflowTileDBDataset,
 )
@@ -64,7 +63,6 @@ class TestTensorflowTileDBDataset:
             generators = [
                 dataset,
                 tensor_generator(
-                    dense_tensor_generator_cls=TensorflowDenseTileDBTensorGenerator,
                     sparse_tensor_generator_cls=TensorflowSparseTileDBTensorGenerator,
                     **dataset_kwargs,
                 ),

--- a/tests/readers/utils.py
+++ b/tests/readers/utils.py
@@ -167,6 +167,8 @@ def _validate_tensor(tensor, batch_size, expected_sparse, expected_shape):
 
 
 def _is_sparse_tensor(tensor):
+    if isinstance(tensor, np.ndarray):
+        return False
     if isinstance(tensor, torch.Tensor):
         return tensor.is_sparse
     if isinstance(tensor, tf.SparseTensor):

--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -8,11 +8,7 @@ import torch
 
 import tiledb
 
-from ._batch_utils import (
-    DenseTileDBTensorGenerator,
-    SparseTileDBTensorGenerator,
-    tensor_generator,
-)
+from ._batch_utils import SparseTileDBTensorGenerator, tensor_generator
 
 
 class PyTorchTileDBDataLoader(torch.utils.data.DataLoader):
@@ -64,8 +60,6 @@ class PyTorchTileDBDataset(torch.utils.data.IterableDataset[Sequence[torch.Tenso
 
         self._rows = rows
         self._generator_kwargs = dict(
-            dense_tensor_generator_cls=PyTorchDenseTileDBTensorGenerator,
-            sparse_tensor_generator_cls=PyTorchSparseTileDBTensorGenerator,
             x_array=x_array,
             y_array=y_array,
             batch_size=batch_size,
@@ -73,6 +67,7 @@ class PyTorchTileDBDataset(torch.utils.data.IterableDataset[Sequence[torch.Tenso
             shuffle=shuffle,
             x_attrs=x_attrs,
             y_attrs=y_attrs,
+            sparse_tensor_generator_cls=PyTorchSparseTileDBTensorGenerator,
         )
 
     def __iter__(self) -> Iterator[Sequence[torch.Tensor]]:
@@ -89,12 +84,6 @@ class PyTorchTileDBDataset(torch.utils.data.IterableDataset[Sequence[torch.Tenso
             stop_offset = min(start_offset + per_worker, self._rows)
             kwargs.update(start_offset=start_offset, stop_offset=stop_offset)
         return tensor_generator(**kwargs)
-
-
-class PyTorchDenseTileDBTensorGenerator(DenseTileDBTensorGenerator[torch.Tensor]):
-    @staticmethod
-    def _tensor_from_numpy(data: np.ndarray) -> torch.Tensor:
-        return torch.from_numpy(data)
 
 
 class PyTorchSparseTileDBTensorGenerator(SparseTileDBTensorGenerator[torch.Tensor]):


### PR DESCRIPTION
I discovered accidentally that it is not necessary to convert numpy arrays to (dense) tensors explicitly using `tf.convert_to_tensor` (for Tensorflow) or `torch.from_numpy` (for PyTorch), it is done implicitly if required. This PR removes the related conversion logic and reduces a bit (or more than a bit in https://github.com/TileDB-Inc/TileDB-ML/pull/124) some extra function call overhead.