### PR TITLE
Replace shuffle parameter with shuffle buffer size

### DIFF
--- a/examples/cloud/models/pytorch_tiledb_cloud_ml_model_array.ipynb
+++ b/examples/cloud/models/pytorch_tiledb_cloud_ml_model_array.ipynb
@@ -32,7 +32,6 @@
     "\n",
     "epochs = 1\n",
     "batch_size_train = 128\n",
-    "batch_size_test = 1000\n",
     "learning_rate = 0.01\n",
     "momentum = 0.5\n",
     "log_interval = 10\n",
@@ -119,7 +118,7 @@
     "                               torchvision.transforms.Normalize(\n",
     "                                 (0.1307,), (0.3081,))\n",
     "                             ])),\n",
-    "  batch_size=batch_size_train, shuffle=True)"
+    "  batch_size=batch_size_train, shuffle_buffer_size=2*batch_size_train)"
    ]
   },
   {

--- a/examples/models/pytorch_tiledb_models_example.ipynb
+++ b/examples/models/pytorch_tiledb_models_example.ipynb
@@ -67,7 +67,6 @@
    "source": [
     "epochs = 1\n",
     "batch_size_train = 128\n",
-    "batch_size_test = 1000\n",
     "learning_rate = 0.01\n",
     "momentum = 0.5\n",
     "log_interval = 10\n",
@@ -108,7 +107,7 @@
     "                               torchvision.transforms.Normalize(\n",
     "                                 (0.1307,), (0.3081,))\n",
     "                             ])),\n",
-    "  batch_size=batch_size_train, shuffle=True)\n"
+    "  batch_size=batch_size_train, shuffle_buffer_size=2*batch_size_train)\n"
    ]
   },
   {

--- a/examples/readers/pytorch_data_api_tiledb_dense.ipynb
+++ b/examples/readers/pytorch_data_api_tiledb_dense.ipynb
@@ -372,7 +372,7 @@
     "    train_loader = PyTorchTileDBDataLoader(x_array=x, y_array=y,\n",
     "                                           batch_size=64,\n",
     "                                           buffer_bytes=1024**2,\n",
-    "                                           shuffle=True)\n",
+    "                                           shuffle_buffer_size=128)\n",
     "    net = Net(shape=(28, 28))\n",
     "    criterion = nn.CrossEntropyLoss()\n",
     "    optimizer = optim.SGD(net.parameters(), lr=0.01, momentum=0.5)\n",

--- a/examples/readers/tensorflow_data_api_tiledb_dense.ipynb
+++ b/examples/readers/tensorflow_data_api_tiledb_dense.ipynb
@@ -340,7 +340,7 @@
     "with tiledb.open(training_images) as x, tiledb.open(training_labels) as y:\n",
     "    tiledb_dataset = TensorflowTileDBDataset(\n",
     "        x_array=x, y_array=y, x_attrs=['features'], y_attrs=['features'], \n",
-    "        batch_size=64, buffer_bytes=1024**2, shuffle=True\n",
+    "        batch_size=64, buffer_bytes=1024**2, shuffle_buffer_size=128\n",
     "    )\n",
     "    model.fit(tiledb_dataset, epochs=5)"
    ]

--- a/tests/readers/test_pytorch.py
+++ b/tests/readers/test_pytorch.py
@@ -27,9 +27,9 @@ class TestPyTorchTileDBDataset:
         y_shape,
         num_attrs,
         pass_attrs,
-        batch_size,
         buffer_bytes,
-        shuffle,
+        batch_size,
+        shuffle_buffer_size,
     ):
         with ingest_in_tiledb(
             tmpdir,
@@ -40,9 +40,7 @@ class TestPyTorchTileDBDataset:
             num_attrs=num_attrs,
             pass_attrs=pass_attrs,
         ) as kwargs:
-            dataset = PyTorchTileDBDataset(
-                buffer_bytes=buffer_bytes, shuffle=shuffle, **kwargs
-            )
+            dataset = PyTorchTileDBDataset(buffer_bytes=buffer_bytes, **kwargs)
             assert isinstance(dataset, torch.utils.data.IterableDataset)
             validate_tensor_generator(
                 dataset, num_attrs, x_sparse, y_sparse, x_shape, y_shape
@@ -61,9 +59,9 @@ class TestPyTorchTileDBDataset:
         y_shape,
         num_attrs,
         pass_attrs,
-        batch_size,
         buffer_bytes,
-        shuffle,
+        batch_size,
+        shuffle_buffer_size,
     ):
         if num_workers and (x_sparse or y_sparse):
             pytest.skip("multiple workers not supported with sparse arrays")
@@ -81,7 +79,7 @@ class TestPyTorchTileDBDataset:
                 num_workers=num_workers,
                 buffer_bytes=buffer_bytes,
                 batch_size=batch_size,
-                shuffle=shuffle,
+                shuffle_buffer_size=shuffle_buffer_size,
                 **kwargs
             )
             assert isinstance(dataloader, torch.utils.data.DataLoader)
@@ -123,9 +121,9 @@ class TestPyTorchTileDBDataset:
         y_shape,
         num_attrs,
         pass_attrs,
-        batch_size,
         buffer_bytes,
-        shuffle,
+        batch_size,
+        shuffle_buffer_size,
     ):
         with ingest_in_tiledb(
             tmpdir,
@@ -142,12 +140,12 @@ class TestPyTorchTileDBDataset:
                     num_workers=num_workers,
                     buffer_bytes=buffer_bytes,
                     batch_size=batch_size,
-                    shuffle=shuffle,
+                    shuffle_buffer_size=shuffle_buffer_size,
                     **kwargs
                 )
             assert "X and Y arrays must have the same number of rows" in str(ex.value)
 
-    @parametrize_for_dataset(x_sparse=[True], shuffle=[False])
+    @parametrize_for_dataset(x_sparse=[True], shuffle_buffer_size=[0])
     def test_sparse_read_order(
         self,
         tmpdir,
@@ -158,9 +156,9 @@ class TestPyTorchTileDBDataset:
         y_shape,
         num_attrs,
         pass_attrs,
-        batch_size,
         buffer_bytes,
-        shuffle,
+        batch_size,
+        shuffle_buffer_size,
     ):
         x_data = rand_array(num_rows, *x_shape, sparse=x_sparse)
         with ingest_in_tiledb(
@@ -175,7 +173,7 @@ class TestPyTorchTileDBDataset:
             dataloader = PyTorchTileDBDataLoader(
                 buffer_bytes=buffer_bytes,
                 batch_size=batch_size,
-                shuffle=shuffle,
+                shuffle_buffer_size=shuffle_buffer_size,
                 **kwargs
             )
             generated_x_data = np.concatenate(

--- a/tests/readers/test_tensorflow.py
+++ b/tests/readers/test_tensorflow.py
@@ -67,7 +67,6 @@ class TestTensorflowTileDBDataset:
             # covered so test it explicitly.
             generator = tensor_generator(
                 buffer_bytes=buffer_bytes,
-                shuffle=shuffle,
                 sparse_tensor_generator_cls=TensorflowSparseTileDBTensorGenerator,
                 **kwargs,
             )

--- a/tests/readers/test_tensorflow.py
+++ b/tests/readers/test_tensorflow.py
@@ -38,9 +38,9 @@ class TestTensorflowTileDBDataset:
         y_shape,
         num_attrs,
         pass_attrs,
-        batch_size,
         buffer_bytes,
-        shuffle,
+        batch_size,
+        shuffle_buffer_size,
     ):
         with ingest_in_tiledb(
             tmpdir,
@@ -54,7 +54,7 @@ class TestTensorflowTileDBDataset:
             dataset = TensorflowTileDBDataset(
                 buffer_bytes=buffer_bytes,
                 batch_size=batch_size,
-                shuffle=shuffle,
+                shuffle_buffer_size=shuffle_buffer_size,
                 **kwargs,
             )
             assert isinstance(dataset, tf.data.Dataset)
@@ -86,9 +86,9 @@ class TestTensorflowTileDBDataset:
         y_shape,
         num_attrs,
         pass_attrs,
-        batch_size,
         buffer_bytes,
-        shuffle,
+        batch_size,
+        shuffle_buffer_size,
     ):
         with ingest_in_tiledb(
             tmpdir,
@@ -104,12 +104,12 @@ class TestTensorflowTileDBDataset:
                 TensorflowTileDBDataset(
                     buffer_bytes=buffer_bytes,
                     batch_size=batch_size,
-                    shuffle=shuffle,
+                    shuffle_buffer_size=shuffle_buffer_size,
                     **kwargs,
                 )
             assert "X and Y arrays must have the same number of rows" in str(ex.value)
 
-    @parametrize_for_dataset(x_sparse=[True], shuffle=[False])
+    @parametrize_for_dataset(x_sparse=[True], shuffle_buffer_size=[0])
     def test_sparse_read_order(
         self,
         tmpdir,
@@ -120,9 +120,9 @@ class TestTensorflowTileDBDataset:
         y_shape,
         num_attrs,
         pass_attrs,
-        batch_size,
         buffer_bytes,
-        shuffle,
+        batch_size,
+        shuffle_buffer_size,
     ):
         x_data = rand_array(num_rows, *x_shape, sparse=x_sparse)
         with ingest_in_tiledb(
@@ -137,7 +137,7 @@ class TestTensorflowTileDBDataset:
             dataset = TensorflowTileDBDataset(
                 buffer_bytes=buffer_bytes,
                 batch_size=batch_size,
-                shuffle=shuffle,
+                shuffle_buffer_size=shuffle_buffer_size,
                 **kwargs,
             )
             generated_x_data = np.concatenate(

--- a/tests/readers/utils.py
+++ b/tests/readers/utils.py
@@ -20,7 +20,7 @@ def parametrize_for_dataset(
     pass_attrs=(True, False),
     batch_size=(8,),
     buffer_bytes=(1024, None),
-    shuffle=(True, False),
+    shuffle_buffer_size=(0, 16),
 ):
     def is_valid_combination(t):
         x_sparse_, y_sparse_, x_shape_, y_shape_, *_ = t
@@ -36,9 +36,9 @@ def parametrize_for_dataset(
         "y_shape",
         "num_attrs",
         "pass_attrs",
-        "batch_size",
         "buffer_bytes",
-        "shuffle",
+        "batch_size",
+        "shuffle_buffer_size",
     ]
     argvalues = filter(
         is_valid_combination,
@@ -49,9 +49,9 @@ def parametrize_for_dataset(
             y_shape,
             num_attrs,
             pass_attrs,
-            batch_size,
             buffer_bytes,
-            shuffle,
+            batch_size,
+            shuffle_buffer_size,
         ),
     )
     return pytest.mark.parametrize(argnames, argvalues)

--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -1,7 +1,9 @@
 """Functionality for loading data from TileDB arrays to the PyTorch Dataloader API."""
 
+import itertools as it
 import math
-from typing import Iterator, Optional, Sequence
+import random
+from typing import Iterable, Iterator, Optional, Sequence, TypeVar
 
 import numpy as np
 import torch
@@ -33,7 +35,9 @@ def PyTorchTileDBDataLoader(
     :param y_attrs: Attribute names of y_array.
     :param num_workers: how many subprocesses to use for data loading
     """
-    dataset = PyTorchTileDBDataset(x_array, y_array, buffer_bytes, x_attrs, y_attrs)
+    dataset = PyTorchTileDBDataset(
+        x_array, y_array, buffer_bytes, shuffle_buffer_size, x_attrs, y_attrs
+    )
     return torch.utils.data.DataLoader(
         dataset, batch_size=batch_size, num_workers=num_workers
     )
@@ -45,6 +49,7 @@ class PyTorchTileDBDataset(torch.utils.data.IterableDataset[Sequence[torch.Tenso
         x_array: tiledb.Array,
         y_array: tiledb.Array,
         buffer_bytes: Optional[int] = None,
+        shuffle_buffer_size: int = 0,
         x_attrs: Sequence[str] = (),
         y_attrs: Sequence[str] = (),
     ):
@@ -54,6 +59,7 @@ class PyTorchTileDBDataset(torch.utils.data.IterableDataset[Sequence[torch.Tenso
             raise ValueError("X and Y arrays must have the same number of rows")
 
         self._rows = rows
+        self._shuffle_buffer_size = shuffle_buffer_size
         self._generator_kwargs = dict(
             x_array=x_array,
             y_array=y_array,
@@ -64,7 +70,7 @@ class PyTorchTileDBDataset(torch.utils.data.IterableDataset[Sequence[torch.Tenso
         )
 
     def __iter__(self) -> Iterator[Sequence[torch.Tensor]]:
-        kwargs = self._generator_kwargs.copy()
+        kwargs = self._generator_kwargs
         worker_info = torch.utils.data.get_worker_info()
         if worker_info is not None:
             for array_key in "x_array", "y_array":
@@ -75,9 +81,39 @@ class PyTorchTileDBDataset(torch.utils.data.IterableDataset[Sequence[torch.Tenso
             per_worker = int(math.ceil(self._rows / worker_info.num_workers))
             start_offset = worker_info.id * per_worker
             stop_offset = min(start_offset + per_worker, self._rows)
-            kwargs.update(start_offset=start_offset, stop_offset=stop_offset)
-        for batch_tensors in tensor_generator(**kwargs):
-            yield from zip(*batch_tensors)
+            kwargs = dict(start_offset=start_offset, stop_offset=stop_offset, **kwargs)
+
+        rows: Iterator[Sequence[torch.Tensor]] = (
+            row
+            for batch_tensors in tensor_generator(**kwargs)
+            for row in zip(*batch_tensors)
+        )
+        if self._shuffle_buffer_size > 0:
+            rows = iter_shuffled(rows, self._shuffle_buffer_size)
+        return rows
+
+
+T = TypeVar("T")
+
+
+def iter_shuffled(iterable: Iterable[T], buffer_size: int) -> Iterator[T]:
+    """
+    Shuffle the given iterable with a buffer.
+
+    The buffer with `buffer_size` is filled with elements from the iterable first.
+    Then, each item will be yielded from the buffer by reservoir sampling via iterator.
+
+    """
+    iterator = iter(iterable)
+    buffer = list(it.islice(iterator, buffer_size))
+    randrange = random.randrange
+    for x in iterator:
+        idx = randrange(0, buffer_size)
+        yield buffer[idx]
+        buffer[idx] = x
+    random.shuffle(buffer)
+    while buffer:
+        yield buffer.pop()
 
 
 class PyTorchSparseTileDBTensorGenerator(SparseTileDBTensorGenerator[torch.Tensor]):

--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -18,14 +18,12 @@ class PyTorchTileDBDataLoader(torch.utils.data.DataLoader):
         y_array: tiledb.Array,
         batch_size: int,
         buffer_bytes: Optional[int] = None,
-        shuffle: bool = False,
+        shuffle_buffer_size: int = 0,
         x_attrs: Sequence[str] = (),
         y_attrs: Sequence[str] = (),
         num_workers: int = 0,
     ):
-        dataset = PyTorchTileDBDataset(
-            x_array, y_array, buffer_bytes, shuffle, x_attrs, y_attrs
-        )
+        dataset = PyTorchTileDBDataset(x_array, y_array, buffer_bytes, x_attrs, y_attrs)
         super().__init__(dataset, batch_size=batch_size, num_workers=num_workers)
 
 
@@ -37,7 +35,6 @@ class PyTorchTileDBDataset(torch.utils.data.IterableDataset[Sequence[torch.Tenso
         x_array: tiledb.Array,
         y_array: tiledb.Array,
         buffer_bytes: Optional[int] = None,
-        shuffle: bool = False,
         x_attrs: Sequence[str] = (),
         y_attrs: Sequence[str] = (),
     ):
@@ -47,7 +44,6 @@ class PyTorchTileDBDataset(torch.utils.data.IterableDataset[Sequence[torch.Tenso
         :param y_array: TileDB array of the labels.
         :param buffer_bytes: Maximum size (in bytes) of memory to allocate for reading
             from each array (default=`tiledb.default_ctx().config()["sm.memory_budget"]`).
-        :param shuffle: True for shuffling rows.
         :param x_attrs: Attribute names of x_array.
         :param y_attrs: Attribute names of y_array.
         """

--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -61,7 +61,6 @@ class PyTorchTileDBDataset(torch.utils.data.IterableDataset[Sequence[torch.Tenso
             x_array=x_array,
             y_array=y_array,
             buffer_bytes=buffer_bytes,
-            shuffle=shuffle,
             x_attrs=x_attrs,
             y_attrs=y_attrs,
             sparse_tensor_generator_cls=PyTorchSparseTileDBTensorGenerator,

--- a/tiledb/ml/readers/tensorflow.py
+++ b/tiledb/ml/readers/tensorflow.py
@@ -48,7 +48,6 @@ def TensorflowTileDBDataset(
                 x_array=x_array,
                 y_array=y_array,
                 buffer_bytes=buffer_bytes,
-                shuffle=shuffle,
                 x_attrs=x_attrs,
                 y_attrs=y_attrs,
                 sparse_tensor_generator_cls=TensorflowSparseTileDBTensorGenerator,

--- a/tiledb/ml/readers/tensorflow.py
+++ b/tiledb/ml/readers/tensorflow.py
@@ -21,7 +21,7 @@ def TensorflowTileDBDataset(
     y_array: tiledb.Array,
     batch_size: int,
     buffer_bytes: Optional[int] = None,
-    shuffle: bool = False,
+    shuffle_buffer_size: int = 0,
     x_attrs: Sequence[str] = (),
     y_attrs: Sequence[str] = (),
 ) -> tf.data.Dataset:
@@ -32,7 +32,7 @@ def TensorflowTileDBDataset(
     :param batch_size: Size of each batch.
     :param buffer_bytes: Maximum size (in bytes) of memory to allocate for reading from
         each array (default=`tiledb.default_ctx().config()["sm.memory_budget"]`).
-    :param shuffle: True for shuffling rows.
+    :param shuffle_buffer_size: Number of elements from which this dataset will sample.
     :param x_attrs: Attribute names of x_array.
     :param y_attrs: Attribute names of y_array.
     """


### PR DESCRIPTION
- [API change] Replace the `shuffle` bool parameter with `shuffle_buffer_size` int.
- Remove the shuffling logic from `tensor_generator`; instead use `Dataset.shuffle()` for Tensorflow and a custom `iter_shuffled` generator for PyTorch.
- Convert `PyTorchTileDBDataLoader` from class to function.