### PR TITLE
Support nD-dim sparse arrays

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ zip_safe = False
 packages = find_namespace:
 python_requires = >=3.7
 test_suite = tests
-install_requires = tiledb == 0.12.3
+install_requires = sparse; tiledb == 0.12.3
 setup_requires = setuptools_scm <= 6.0.0
 
 [options.extras_require]

--- a/tests/readers/utils.py
+++ b/tests/readers/utils.py
@@ -22,13 +22,6 @@ def parametrize_for_dataset(
     buffer_bytes=(1024, None),
     shuffle_buffer_size=(0, 16),
 ):
-    def is_valid_combination(t):
-        x_sparse_, y_sparse_, x_shape_, y_shape_, *_ = t
-        # sparse not supported with multi-dimensional arrays
-        if x_sparse_ and len(x_shape_) > 1 or y_sparse_ and len(y_shape_) > 1:
-            return False
-        return True
-
     argnames = [
         "x_sparse",
         "y_sparse",
@@ -40,19 +33,16 @@ def parametrize_for_dataset(
         "batch_size",
         "shuffle_buffer_size",
     ]
-    argvalues = filter(
-        is_valid_combination,
-        it.product(
-            x_sparse,
-            y_sparse,
-            x_shape,
-            y_shape,
-            num_attrs,
-            pass_attrs,
-            buffer_bytes,
-            batch_size,
-            shuffle_buffer_size,
-        ),
+    argvalues = it.product(
+        x_sparse,
+        y_sparse,
+        x_shape,
+        y_shape,
+        num_attrs,
+        pass_attrs,
+        buffer_bytes,
+        batch_size,
+        shuffle_buffer_size,
     )
     return pytest.mark.parametrize(argnames, argvalues)
 

--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -6,6 +6,7 @@ import random
 from typing import Any, Callable, Iterable, Iterator, Optional, Sequence, TypeVar
 
 import numpy as np
+import sparse
 import torch
 
 import tiledb
@@ -168,12 +169,5 @@ def iter_shuffled(iterable: Iterable[T], buffer_size: int) -> Iterator[T]:
 
 class PyTorchSparseTensorGenerator(TileDBSparseTensorGenerator[torch.Tensor]):
     @staticmethod
-    def _tensor_from_coo(
-        data: np.ndarray,
-        coords: np.ndarray,
-        dense_shape: Sequence[int],
-        dtype: np.dtype,
-    ) -> torch.Tensor:
-        return torch.sparse_coo_tensor(
-            torch.tensor(coords).t(), data, dense_shape, requires_grad=False
-        )
+    def _tensor_from_coo(coo: sparse.COO) -> torch.Tensor:
+        return torch.sparse_coo_tensor(coo.coords, coo.data, coo.shape)

--- a/tiledb/ml/readers/tensorflow.py
+++ b/tiledb/ml/readers/tensorflow.py
@@ -3,7 +3,7 @@
 from functools import partial
 from typing import Iterator, Optional, Sequence, Union
 
-import numpy as np
+import sparse
 import tensorflow as tf
 
 import tiledb
@@ -79,14 +79,5 @@ def _iter_tensor_specs(
 
 class TensorflowSparseTensorGenerator(TileDBSparseTensorGenerator[tf.SparseTensor]):
     @staticmethod
-    def _tensor_from_coo(
-        data: np.ndarray,
-        coords: np.ndarray,
-        dense_shape: Sequence[int],
-        dtype: np.dtype,
-    ) -> tf.SparseTensor:
-        return tf.SparseTensor(
-            indices=tf.constant(coords, dtype=tf.int64),
-            values=tf.constant(data, dtype=dtype),
-            dense_shape=dense_shape,
-        )
+    def _tensor_from_coo(coo: sparse.COO) -> tf.SparseTensor:
+        return tf.SparseTensor(coo.coords.T, coo.data, coo.shape)


### PR DESCRIPTION
Extend support for sparse arrays from 2D to nD, using [pydata/sparse](https://sparse.pydata.org/en/stable/) in place of `scipy.sparse`.

Also some minor `_tensor_gen` refactoring:
- Merge `TileDBTensorGenerator` with `TileDBNumpyGenerator`
- Change `TileDBSparseTensorGenerator._tensor_from_coo` signature
- Drop `dense_generator_cls` parameter from `tensor_generator` and make `sparse_generator_cls` required