### PR TITLE
Implement parallelized TensorflowTileDBDataset

### DIFF
--- a/tests/readers/test_pytorch.py
+++ b/tests/readers/test_pytorch.py
@@ -14,13 +14,13 @@ from .utils import (
 )
 
 
-@pytest.mark.parametrize("num_rows", [107])
 class TestPyTorchTileDBDataset:
-    @parametrize_for_dataset()
+    @parametrize_for_dataset(batch_size=[0], shuffle_buffer_size=[0], num_workers=[0])
     def test_dataset(
         self,
         tmpdir,
         num_rows,
+        num_workers,
         x_sparse,
         y_sparse,
         x_shape,
@@ -47,7 +47,6 @@ class TestPyTorchTileDBDataset:
             )
 
     @parametrize_for_dataset()
-    @pytest.mark.parametrize("num_workers", [0, 2])
     def test_dataloader(
         self,
         tmpdir,
@@ -109,7 +108,6 @@ class TestPyTorchTileDBDataset:
                 assert len(unique_y_tensors) - 1 == batchindx
 
     @parametrize_for_dataset()
-    @pytest.mark.parametrize("num_workers", [0, 2])
     def test_unequal_num_rows(
         self,
         tmpdir,
@@ -145,11 +143,12 @@ class TestPyTorchTileDBDataset:
                 )
             assert "X and Y arrays must have the same number of rows" in str(ex.value)
 
-    @parametrize_for_dataset(x_sparse=[True], shuffle_buffer_size=[0])
+    @parametrize_for_dataset(x_sparse=[True], shuffle_buffer_size=[0], num_workers=[0])
     def test_sparse_read_order(
         self,
         tmpdir,
         num_rows,
+        num_workers,
         x_sparse,
         y_sparse,
         x_shape,
@@ -174,6 +173,7 @@ class TestPyTorchTileDBDataset:
                 buffer_bytes=buffer_bytes,
                 batch_size=batch_size,
                 shuffle_buffer_size=shuffle_buffer_size,
+                num_workers=num_workers,
                 **kwargs
             )
             generated_x_data = np.concatenate(

--- a/tests/readers/test_tensorflow.py
+++ b/tests/readers/test_tensorflow.py
@@ -14,13 +14,13 @@ from .utils import (
 )
 
 
-@pytest.mark.parametrize("num_rows", [107])
 class TestTensorflowTileDBDataset:
     @parametrize_for_dataset()
     def test_dataset(
         self,
         tmpdir,
         num_rows,
+        num_workers,
         x_sparse,
         y_sparse,
         x_shape,
@@ -44,6 +44,7 @@ class TestTensorflowTileDBDataset:
                 buffer_bytes=buffer_bytes,
                 batch_size=batch_size,
                 shuffle_buffer_size=shuffle_buffer_size,
+                num_workers=num_workers,
                 **kwargs,
             )
             assert isinstance(dataset, tf.data.Dataset)
@@ -56,6 +57,7 @@ class TestTensorflowTileDBDataset:
         self,
         tmpdir,
         num_rows,
+        num_workers,
         x_sparse,
         y_sparse,
         x_shape,
@@ -81,15 +83,17 @@ class TestTensorflowTileDBDataset:
                     buffer_bytes=buffer_bytes,
                     batch_size=batch_size,
                     shuffle_buffer_size=shuffle_buffer_size,
+                    num_workers=num_workers,
                     **kwargs,
                 )
             assert "X and Y arrays must have the same number of rows" in str(ex.value)
 
-    @parametrize_for_dataset(x_sparse=[True], shuffle_buffer_size=[0])
+    @parametrize_for_dataset(x_sparse=[True], shuffle_buffer_size=[0], num_workers=[0])
     def test_sparse_read_order(
         self,
         tmpdir,
         num_rows,
+        num_workers,
         x_sparse,
         y_sparse,
         x_shape,
@@ -114,6 +118,7 @@ class TestTensorflowTileDBDataset:
                 buffer_bytes=buffer_bytes,
                 batch_size=batch_size,
                 shuffle_buffer_size=shuffle_buffer_size,
+                num_workers=num_workers,
                 **kwargs,
             )
             generated_x_data = np.concatenate(

--- a/tests/readers/utils.py
+++ b/tests/readers/utils.py
@@ -12,6 +12,8 @@ import tiledb
 
 
 def parametrize_for_dataset(
+    num_rows=(107,),
+    num_workers=(0, 2),
     x_sparse=(True, False),
     y_sparse=(True, False),
     x_shape=((10,), (10, 3)),
@@ -23,6 +25,8 @@ def parametrize_for_dataset(
     shuffle_buffer_size=(0, 16),
 ):
     argnames = [
+        "num_rows",
+        "num_workers",
         "x_sparse",
         "y_sparse",
         "x_shape",
@@ -34,6 +38,8 @@ def parametrize_for_dataset(
         "shuffle_buffer_size",
     ]
     argvalues = it.product(
+        num_rows,
+        num_workers,
         x_sparse,
         y_sparse,
         x_shape,

--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -39,7 +39,9 @@ def PyTorchTileDBDataLoader(
     :param shuffle_buffer_size: Number of elements from which this dataset will sample.
     :param x_attrs: Attribute names of x_array.
     :param y_attrs: Attribute names of y_array.
-    :param num_workers: how many subprocesses to use for data loading
+    :param num_workers: how many subprocesses to use for data loading. 0 means that the
+        data will be loaded in the main process. Note: yielded batches may be shuffled
+        even if `shuffle_buffer_size` is zero when `num_workers` > 1.
     """
     x_schema = x_array.schema
     y_schema = y_array.schema


### PR DESCRIPTION
Add `num_workers` parameter to `TensorflowTileDBDataset` to match the `PyTorchTileDBDataLoader` API. This is implemented via [tf.data.Dataset.interleave](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#interleave) that uses a threadpool for fetching inputs asynchronously and in parallel.

**Note**: both `TensorflowTileDBDataset` and `PyTorchTileDBDataLoader` may yield shuffled batches wihen `num_workers > 1` even when `shuffle_buffer_size = 0`.