### PR TITLE
Expose TileDB-ML version at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.7, 3.8]
     env:
       run_coverage: ${{ github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
     env:
       run_coverage: ${{ github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' }}
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from importlib.metadata import PackageNotFoundError, version
+
 import setuptools
 
 setuptools.setup(
@@ -7,3 +9,9 @@ setuptools.setup(
         "write_to": "tiledb/ml/version.py",
     }
 )
+
+try:
+    __version__ = version("package-name")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,9 @@
-from importlib.metadata import PackageNotFoundError, version
-
 import setuptools
 
 setuptools.setup(
     use_scm_version={
         "version_scheme": "guess-next-dev",
-        "local_scheme": "no-local-version",
+        "local_scheme": "dirty-tag",
         "write_to": "tiledb/ml/version.py",
     }
 )
-
-try:
-    __version__ = version("package-name")
-except PackageNotFoundError:
-    # package is not installed
-    pass

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import setuptools
+from pkg_resources import DistributionNotFound, get_distribution  # type: ignore
 
 setuptools.setup(
     use_scm_version={
@@ -7,3 +8,9 @@ setuptools.setup(
         "write_to": "tiledb/ml/version.py",
     }
 )
+
+try:
+    __version__ = get_distribution("tiledb-ml").version
+except DistributionNotFound:
+    # package is not installed
+    pass

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,4 @@
 import setuptools
-from pkg_resources import DistributionNotFound, get_distribution  # type: ignore
-
-# TODO change pkg_resources with importlib.metadata, as described here
-#  https://pypi.org/project/setuptools-scm/#:~:text=Retrieving%20package%20version%20at%20runtime, when we stop
-#  supporting Python 3.7. We the aforementioned change, we can avoid the 100ms overhead during import of the package.
 
 setuptools.setup(
     use_scm_version={
@@ -12,9 +7,3 @@ setuptools.setup(
         "write_to": "tiledb/ml/version.py",
     }
 )
-
-try:
-    __version__ = get_distribution("tiledb-ml").version
-except DistributionNotFound:
-    # package is not installed
-    pass

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 import setuptools
 from pkg_resources import DistributionNotFound, get_distribution  # type: ignore
 
+# TODO change pkg_resources with importlib.metadata, as described here
+#  https://pypi.org/project/setuptools-scm/#:~:text=Retrieving%20package%20version%20at%20runtime, when we stop
+#  supporting Python 3.7. We the aforementioned change, we can avoid the 100ms overhead during import of the package.
+
 setuptools.setup(
     use_scm_version={
         "version_scheme": "guess-next-dev",

--- a/tiledb/ml/__init__.py
+++ b/tiledb/ml/__init__.py
@@ -1,0 +1,11 @@
+from pkg_resources import DistributionNotFound, get_distribution  # type: ignore
+
+# TODO change pkg_resources with importlib.metadata, as described here
+#  https://pypi.org/project/setuptools-scm/#:~:text=Retrieving%20package%20version%20at%20runtime, when we stop
+#  supporting Python 3.7. We the aforementioned change, we can avoid the 100ms overhead during import of the package.
+
+try:
+    __version__ = get_distribution("tiledb-ml").version
+except DistributionNotFound:
+    # package is not installed
+    pass


### PR DESCRIPTION
This PR is about exposing TileDB-ML version at runtime via a _version_ variable.

Minor changes to the following:

- `setup.py`
- `tiledb/ml/__init__.py`