### PR TITLE
Always generate (x,y) tuples

### DIFF
--- a/tests/readers/test_tensorflow.py
+++ b/tests/readers/test_tensorflow.py
@@ -123,8 +123,10 @@ class TestTensorflowTileDBDataset:
             )
             generated_x_data = np.concatenate(
                 [
-                    tf.sparse.to_dense(tf.sparse.reorder(tensors[0]))
-                    for tensors in dataset
+                    tf.sparse.to_dense(
+                        tf.sparse.reorder(x_tensors if num_attrs == 1 else x_tensors[0])
+                    )
+                    for x_tensors, y_tensors in dataset
                 ]
             )
             np.testing.assert_array_almost_equal(generated_x_data, x_data)

--- a/tests/readers/utils.py
+++ b/tests/readers/utils.py
@@ -133,14 +133,11 @@ def rand_array(num_rows: int, *row_shape: int, sparse: bool = False) -> np.ndarr
 def validate_tensor_generator(
     generator, num_attrs, x_sparse, y_sparse, x_shape, y_shape, batch_size=None
 ):
-    for tensors in generator:
-        assert len(tensors) == 2 * num_attrs
-        # the first num_attrs tensors are the features (x)
-        for tensor in tensors[:num_attrs]:
-            _validate_tensor(tensor, x_sparse, x_shape, batch_size)
-        # the last num_attrs tensors are the labels (y)
-        for tensor in tensors[num_attrs:]:
-            _validate_tensor(tensor, y_sparse, y_shape, batch_size)
+    for x_tensors, y_tensors in generator:
+        for x_tensor in x_tensors if num_attrs > 1 else [x_tensors]:
+            _validate_tensor(x_tensor, x_sparse, x_shape, batch_size)
+        for y_tensor in y_tensors if num_attrs > 1 else [y_tensors]:
+            _validate_tensor(y_tensor, y_sparse, y_shape, batch_size)
 
 
 def _validate_tensor(tensor, expected_sparse, expected_shape, batch_size=None):

--- a/tiledb/ml/readers/_tensor_gen.py
+++ b/tiledb/ml/readers/_tensor_gen.py
@@ -1,19 +1,17 @@
-from typing import Callable, Generic, Iterator, Sequence, TypeVar
+from abc import ABC, abstractmethod
+from operator import itemgetter
+from typing import Callable, Generic, Iterator, Sequence, TypeVar, Union
 
 import numpy as np
 import sparse
 
 import tiledb
 
-
-def iter_slices(start: int, stop: int, step: int) -> Iterator[slice]:
-    offsets = range(start, stop, step)
-    yield from map(slice, offsets, offsets[1:])
-    yield slice(offsets[-1], stop)
+T = TypeVar("T")
 
 
-class TileDBNumpyGenerator:
-    """Generator of Numpy tensors read from a TileDB array."""
+class TileDBTensorGenerator(ABC, Generic[T]):
+    """Generator of tensors read from a TileDB array."""
 
     def __init__(self, array: tiledb.Array, attrs: Sequence[str]) -> None:
         """
@@ -23,28 +21,42 @@ class TileDBNumpyGenerator:
         self._array = array
         self._attrs = attrs
 
+    @property
+    def single_attr(self) -> bool:
+        """Whether this generator reads a single attribute."""
+        return len(self._attrs) == 1
+
+    @abstractmethod
     def iter_tensors(
         self, buffer_size: int, start_offset: int, stop_offset: int
-    ) -> Iterator[Sequence[np.ndarray]]:
+    ) -> Union[Iterator[T], Iterator[Sequence[T]]]:
         """
         Generate batches of tensors.
 
-        Each yielded batch is a sequence of N tensors where `N == len(self.attrs)`.
-        Each tensor is a NumPy array of shape `(buffer_size, *self.array.shape[1:])`.
+        Each yielded batch is either:
+        - a sequence of N tensors where `N == len(self.attrs)` if N > 1, or
+        - a single tensor if N == 1.
+        Each tensor is a `T` instance of shape `(buffer_size, *self.array.shape[1:])`.
 
         :param buffer_size: Size of each slice of rows to read.
         :param start_offset: Start row offset; defaults to 0.
         :param stop_offset: Stop row offset; defaults to number of rows.
         """
+
+
+class TileDBNumpyGenerator(TileDBTensorGenerator[np.ndarray]):
+    """Generator of Numpy arrays read from a TileDB array."""
+
+    def iter_tensors(
+        self, buffer_size: int, start_offset: int, stop_offset: int
+    ) -> Union[Iterator[np.ndarray], Iterator[Sequence[np.ndarray]]]:
         query = self._array.query(attrs=self._attrs)
-        for read_slice in iter_slices(start_offset, stop_offset, buffer_size):
-            yield tuple(query[read_slice].values())
+        read_slices = iter_slices(start_offset, stop_offset, buffer_size)
+        buffers = map(query.__getitem__, read_slices)
+        return map(itemgetter(*self._attrs), buffers)
 
 
-T = TypeVar("T")
-
-
-class TileDBSparseGenerator(Generic[T]):
+class TileDBSparseGenerator(TileDBTensorGenerator[T]):
     """Generator of sparse.COO tensors read from a TileDB array."""
 
     def __init__(
@@ -53,34 +65,32 @@ class TileDBSparseGenerator(Generic[T]):
         attrs: Sequence[str],
         from_coo: Callable[[sparse.COO], T],
     ) -> None:
-        self._array = array
-        self._attrs = attrs
+        super().__init__(array, attrs)
         self._from_coo = from_coo
         self._dims = tuple(array.domain.dim(i).name for i in range(array.ndim))
-        self._row_shape = array.shape[1:]
 
     def iter_tensors(
         self, buffer_size: int, start_offset: int, stop_offset: int
-    ) -> Iterator[Sequence[T]]:
-        """
-        Generate batches of tensors.
-
-        Each yielded batch is a sequence of N tensors where `N == len(self.attrs)`.
-        Each tensor is a `Tensor` of shape `(buffer_size, *self.array.shape[1:])`.
-
-        :param buffer_size: Size of each slice of rows to read.
-        :param start_offset: Start row offset; defaults to 0.
-        :param stop_offset: Stop row offset; defaults to number of rows.
-        """
+    ) -> Union[Iterator[T], Iterator[Sequence[T]]]:
+        shape = list(self._array.shape)
         query = self._array.query(attrs=self._attrs)
-        from_coo = self._from_coo
+        get_coords = itemgetter(*self._dims)
+        get_data = itemgetter(*self._attrs)
+        single_attr = self.single_attr
         for read_slice in iter_slices(start_offset, stop_offset, buffer_size):
+            shape[0] = read_slice.stop - read_slice.start
             buffer = query[read_slice]
-            coords = [buffer.pop(dim) for dim in self._dims]
+            coords = get_coords(buffer)
             # normalize the first coordinate dimension to start at start_offset
-            start = read_slice.start
-            if start:
-                coords[0] -= start
-            shape = (read_slice.stop - start, *self._row_shape)
-            coos = (sparse.COO(coords, data, shape) for data in buffer.values())
-            yield tuple(map(from_coo, coos))
+            np.subtract(coords[0], read_slice.start, out=coords[0])
+            data = get_data(buffer)
+            if single_attr:
+                yield self._from_coo(sparse.COO(coords, data, shape))
+            else:
+                yield tuple(self._from_coo(sparse.COO(coords, d, shape)) for d in data)
+
+
+def iter_slices(start: int, stop: int, step: int) -> Iterator[slice]:
+    offsets = range(start, stop, step)
+    yield from map(slice, offsets, offsets[1:])
+    yield slice(offsets[-1], stop)


### PR DESCRIPTION
Currently the data loaders concatenate the tensors for all selected attributes in a flat tuple. For example, when selecting 2 `x` and 3 `y` attributes, each generated tuple has length 5: `(x0, x1, y0, y1, y2)`. This is not compatible with how ML frameworks work; they expect `(x, y)` tuples.

This PR change the data loaders so that they always generate `(x, y)` tuples, where 
- `x` is a nested tuple of tensors if `len(x_attrs) > 1`, otherwise it's a standalone tensor
- likewise, `y` is a nested tuple of tensors if `len(y_attrs) > 1`, otherwise it's a standalone tensor
