### PR TITLE
Improve dependency versioning, add CI for multiple dependency versions, fix support for older ML versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,49 +4,56 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
+      fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest]
-        python-version: [3.7, 3.8]
+        ml-deps:
+          - "scikit-learn=1.0 pytorch=1.8.1 tensorflow=2.4.3 numpy=1.19"
+          - "scikit-learn=1.0 pytorch=1.9.1 tensorflow=2.4.1 numpy=1.19"
+          - "scikit-learn=1.0 pytorch=1.10  tensorflow=2.6.2=cpu*"
+          - "scikit-learn=1.0 pytorch=1.11  tensorflow=2.7.0=cpu*"
     env:
-      run_coverage: ${{ github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' }}
+      run_coverage: ${{ github.ref == 'refs/heads/master' }}
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+
+    - name: Set up miniconda
+      uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.7"
+        mamba-version: "*"
+        channels: conda-forge,defaults
 
-    - name: 'Install dependencies'
+    - name: Install dependencies
+      run: mamba install pytest-mock pytest-cov ${{ matrix.ml-deps }}
+
+    - name: Install TileDB-ML
+      run: pip install -e .[cloud]
+
+    - name: Run mypy
       run: |
-        pip install --upgrade pip
-        pip install -e .[full]
+        conda activate base
+        mamba install mypy
+        mypy .
 
-    - name: 'Run mypy'
-      run: |
-        python -m venv mypyenv
-        mypyenv/bin/pip install mypy
-        mypyenv/bin/mypy .
-        rm -rf mypyenv
-
-    - name: 'Run tests'
+    - name: Run tests
       if: ${{ !fromJSON(env.run_coverage) }}
-      run: |
-        pip install pytest-mock
-        pytest tests/
+      run: pytest --disable-warnings tests/
 
-    - name: 'Run test coverage statistics'
+    - name: Run test coverage statistics
       id: stats
       if: ${{ fromJSON(env.run_coverage) }}
       run: |
-        pip install pytest-mock pytest-cov
-        pytest --cov-report=term-missing --cov=tiledb tests/ | tee coverage.txt
+        pytest --disable-warnings --cov-report=term-missing --cov=tiledb tests/ | tee coverage.txt
         TEST_COVERAGE="$(grep '^TOTAL' coverage.txt | awk -v N=4 '{print $N}')"
         echo "::set-output name=COVERAGE::$TEST_COVERAGE"
 
-    - name: 'Create Test Coverage Badge'
+    - name: Create Test Coverage Badge
       if: ${{ fromJSON(env.run_coverage) }}
       uses: schneegans/dynamic-badges-action@v1.1.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,13 @@ jobs:
       with:
         python-version: "3.7"
 
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.ml-deps }}
+        restore-keys: ${{ runner.os }}-pip-
+
     - name: Install dependencies
       run: |
         pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,37 +12,38 @@ jobs:
       fail-fast: false
       matrix:
         ml-deps:
-          - "scikit-learn=1.0 pytorch=1.8.1 tensorflow=2.4.3 numpy=1.19"
-          - "scikit-learn=1.0 pytorch=1.9.1 tensorflow=2.4.1 numpy=1.19"
-          - "scikit-learn=1.0 pytorch=1.10 tensorflow=2.4.1 numpy=1.19"
-          - "scikit-learn=1.0 pytorch=1.11 tensorflow=2.4.1 numpy=1.19"
+          - "torch==1.8.1+cpu tensorflow-cpu==2.4.4"
+          - "torch==1.9.1+cpu tensorflow-cpu==2.5.3"
+          - "torch==1.10.2+cpu tensorflow-cpu==2.4.4"
+          - "torch==1.11.0+cpu tensorflow-cpu==2.4.4"
           # remove the previous two lines and uncomment the next two after 2.6+ support
-          # - "scikit-learn=1.0 pytorch=1.10  tensorflow=2.6.2=cpu*"
-          # - "scikit-learn=1.0 pytorch=1.11  tensorflow=2.7.0=cpu*"
+          # - "torch==1.10.2+cpu tensorflow-cpu==2.6.3"
+          # - "torch==1.11.0+cpu tensorflow-cpu==2.7.1"
+
     env:
       run_coverage: ${{ github.ref == 'refs/heads/master' }}
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up miniconda
-      uses: conda-incubator/setup-miniconda@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
       with:
         python-version: "3.7"
-        mamba-version: "*"
-        channels: conda-forge,defaults
 
     - name: Install dependencies
-      run: mamba install pytest-mock pytest-cov ${{ matrix.ml-deps }}
-
-    - name: Install TileDB-ML
-      run: pip install -e .[cloud]
+      run: |
+        pip install --upgrade pip
+        pip install -f https://download.pytorch.org/whl/torch_stable.html \
+          pytest-mock pytest-cov scikit-learn==1.0.2 ${{ matrix.ml-deps }}
+        pip install -e .[cloud]
 
     - name: Run mypy
       run: |
-        conda activate base
-        mamba install mypy
-        mypy .
+        python -m venv mypyenv
+        mypyenv/bin/pip install mypy
+        mypyenv/bin/mypy .
+        rm -rf mypyenv
 
     - name: Run tests
       if: ${{ !fromJSON(env.run_coverage) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,11 @@ jobs:
         ml-deps:
           - "scikit-learn=1.0 pytorch=1.8.1 tensorflow=2.4.3 numpy=1.19"
           - "scikit-learn=1.0 pytorch=1.9.1 tensorflow=2.4.1 numpy=1.19"
-          - "scikit-learn=1.0 pytorch=1.10  tensorflow=2.6.2=cpu*"
-          - "scikit-learn=1.0 pytorch=1.11  tensorflow=2.7.0=cpu*"
+          - "scikit-learn=1.0 pytorch=1.10 tensorflow=2.4.1 numpy=1.19"
+          - "scikit-learn=1.0 pytorch=1.11 tensorflow=2.4.1 numpy=1.19"
+          # remove the previous two lines and uncomment the next two after 2.6+ support
+          # - "scikit-learn=1.0 pytorch=1.10  tensorflow=2.6.2=cpu*"
+          # - "scikit-learn=1.0 pytorch=1.11  tensorflow=2.7.0=cpu*"
     env:
       run_coverage: ${{ github.ref == 'refs/heads/master' }}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,17 +34,6 @@ zip_safe = False
 packages = find_namespace:
 python_requires = >=3.7
 test_suite = tests
-install_requires = sparse; tiledb >= 0.14
-setup_requires = setuptools_scm <= 6.0.0
-
-[options.extras_require]
-tensorflow = tensorflow<=2.5.0;
-pytorch = torch>=1.8.1, <1.10; torchvision>=0.9.1
-sklearn = scikit-learn>=0.23.0
-tensorflow_cloud = tensorflow<=2.5.0; tiledb-cloud>=0.7.11
-pytorch_cloud = torch>=1.8.1, <1.10; torchvision>=0.9.1; tiledb-cloud>=0.7.11
-sklearn_cloud = scikit-learn>=0.23.0; tiledb-cloud>=0.7.11
-full = tensorflow<=2.5.0; torch>=1.8.1, <1.10; torchvision>=0.9.1; scikit-learn>=0.23.0; tiledb-cloud>=0.7.11
 
 [aliases]
 test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-tensorflow = ["tensorflow>=2.4.1"]
+tensorflow = ["tensorflow>=2.4.1,<2.6"]
 pytorch = ["torch>=1.8.1"]
 sklearn = ["scikit-learn>=1.0"]
 cloud = ["tiledb-cloud"]

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,24 @@
 import setuptools
 
+tensorflow = ["tensorflow<=2.5.0"]
+pytorch = ["torch>=1.8.1, <1.10"]
+sklearn = ["scikit-learn>=0.23.0"]
+cloud = ["tiledb-cloud>=0.7.11"]
+full = sorted({"torchvision>=0.9.1", *tensorflow, *pytorch, *sklearn, *cloud})
+
 setuptools.setup(
+    setup_requires=["setuptools_scm <= 6.0"],
     use_scm_version={
         "version_scheme": "guess-next-dev",
         "local_scheme": "dirty-tag",
         "write_to": "tiledb/ml/version.py",
-    }
+    },
+    install_requires=["sparse", "tiledb >= 0.14"],
+    extras_require={
+        "tensorflow": tensorflow,
+        "pytorch": pytorch,
+        "sklearn": sklearn,
+        "cloud": cloud,
+        "full": full,
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,19 @@
 import setuptools
 
-tensorflow = ["tensorflow<=2.5.0"]
-pytorch = ["torch>=1.8.1, <1.10"]
-sklearn = ["scikit-learn>=0.23.0"]
-cloud = ["tiledb-cloud>=0.7.11"]
-full = sorted({"torchvision>=0.9.1", *tensorflow, *pytorch, *sklearn, *cloud})
+tensorflow = ["tensorflow>=2.4.1"]
+pytorch = ["torch>=1.8.1"]
+sklearn = ["scikit-learn>=1.0"]
+cloud = ["tiledb-cloud"]
+full = sorted({"torchvision", *tensorflow, *pytorch, *sklearn, *cloud})
 
 setuptools.setup(
-    setup_requires=["setuptools_scm <= 6.0"],
+    setup_requires=["setuptools_scm"],
     use_scm_version={
         "version_scheme": "guess-next-dev",
         "local_scheme": "dirty-tag",
         "write_to": "tiledb/ml/version.py",
     },
-    install_requires=["sparse", "tiledb >= 0.14"],
+    install_requires=["sparse", "tiledb>=0.14"],
     extras_require={
         "tensorflow": tensorflow,
         "pytorch": pytorch,

--- a/tests/readers/utils.py
+++ b/tests/readers/utils.py
@@ -157,7 +157,8 @@ def _validate_tensor(tensor, expected_sparse, expected_shape, batch_size=None):
 
 def _is_sparse(tensor):
     if isinstance(tensor, torch.Tensor):
-        return tensor.layout in (torch.sparse_coo, torch.sparse_csr)
+        # torch.sparse_csr introduced in torch>=1.9
+        return tensor.layout in (torch.sparse_coo, getattr(torch, "sparse_csr", None))
     if isinstance(tensor, (scipy.sparse.spmatrix, sparse.SparseArray, tf.SparseTensor)):
         return True
     if isinstance(tensor, (np.ndarray, tf.Tensor)):

--- a/tiledb/ml/models/tensorflow_keras.py
+++ b/tiledb/ml/models/tensorflow_keras.py
@@ -1,5 +1,6 @@
 """Functionality for saving and loading Tensorflow Keras models as TileDB arrays"""
 
+import contextlib
 import io
 import json
 import logging
@@ -22,6 +23,11 @@ import tiledb
 
 from ._cloud_utils import update_file_properties
 from .base import Meta, TileDBModel, Timestamp, current_milli_time
+
+# SharedObjectLoadingScope was introduced in TensorFlow 2.5
+SharedObjectLoadingScope = getattr(
+    generic_utils, "SharedObjectLoadingScope", contextlib.nullcontext
+)
 
 
 class TensorflowKerasTileDBModel(TileDBModel[tf.keras.Model]):
@@ -97,7 +103,7 @@ class TensorflowKerasTileDBModel(TileDBModel[tf.keras.Model]):
             model_class = model_config["class_name"]
 
             if model_class != "Sequential" and model_class != "Functional":
-                with generic_utils.SharedObjectLoadingScope():
+                with SharedObjectLoadingScope():
                     with generic_utils.CustomObjectScope(custom_objects or {}):
                         if hasattr(model_config, "decode"):
                             model_config = model_config.decode("utf-8")


### PR DESCRIPTION
- Tighter dependency versioning
  - Moved requirements from `setup.cfg` to `setup.py` for more flexibility and DRY logic.
  - Removed the `tiledb-ml[FOO_cloud]` optional requirements; use `tiledb-ml[FOO,cloud]` instead. 
  - Removed `torchvision` from the `pytorch` dependencies; still kept it for the `full` optional dependency.
  - Updated versioning of remaining dependencies.
- Revamped CI:
  - Run tests for several Tensorflow/Pytorch versions.
  - Fix platform to `ubuntu-latest` and python to `3.7`.
  - Cache pip requirements.
- Fixes:
  - `pytorch<1.9`: CSR tensors not available - raise `RuntimeError` if `csr==True`.
  - `Tensorflow<2.5`: `SharedObjectLoadingScope` not available - fall back to a no-op context (`contextlib.nullcontext`).