### PR TITLE
Custom key dimension

### DIFF
--- a/tests/readers/test_pytorch.py
+++ b/tests/readers/test_pytorch.py
@@ -22,6 +22,8 @@ class TestPyTorchTileDBDataset:
         y_shape,
         x_sparse,
         y_sparse,
+        x_key_dim,
+        y_key_dim,
         num_attrs,
         pass_attrs,
         buffer_bytes,
@@ -30,16 +32,20 @@ class TestPyTorchTileDBDataset:
         num_workers,
     ):
         with ingest_in_tiledb(
-            tmpdir, x_shape, x_sparse, num_attrs, pass_attrs
+            tmpdir, x_shape, x_sparse, x_key_dim, num_attrs, pass_attrs
         ) as x_kwargs, ingest_in_tiledb(
-            tmpdir, y_shape, y_sparse, num_attrs, pass_attrs
+            tmpdir, y_shape, y_sparse, y_key_dim, num_attrs, pass_attrs
         ) as y_kwargs:
             x_array, y_array = x_kwargs["array"], y_kwargs["array"]
             dataset = PyTorchTileDBDataset(
                 x_array=x_array,
                 y_array=y_array,
-                x_schema=TensorSchema(x_array.schema, attrs=x_kwargs["attrs"]),
-                y_schema=TensorSchema(y_array.schema, attrs=y_kwargs["attrs"]),
+                x_schema=TensorSchema(
+                    x_array.schema, x_kwargs["key_dim"], x_kwargs["attrs"]
+                ),
+                y_schema=TensorSchema(
+                    y_array.schema, y_kwargs["key_dim"], y_kwargs["attrs"]
+                ),
                 buffer_bytes=buffer_bytes,
             )
             assert isinstance(dataset, torch.utils.data.IterableDataset)
@@ -55,6 +61,8 @@ class TestPyTorchTileDBDataset:
         y_shape,
         x_sparse,
         y_sparse,
+        x_key_dim,
+        y_key_dim,
         num_attrs,
         pass_attrs,
         buffer_bytes,
@@ -66,15 +74,17 @@ class TestPyTorchTileDBDataset:
             pytest.skip("multiple workers not supported with sparse arrays")
 
         with ingest_in_tiledb(
-            tmpdir, x_shape, x_sparse, num_attrs, pass_attrs
+            tmpdir, x_shape, x_sparse, x_key_dim, num_attrs, pass_attrs
         ) as x_kwargs, ingest_in_tiledb(
-            tmpdir, y_shape, y_sparse, num_attrs, pass_attrs
+            tmpdir, y_shape, y_sparse, y_key_dim, num_attrs, pass_attrs
         ) as y_kwargs:
             dataloader = PyTorchTileDBDataLoader(
                 x_array=x_kwargs["array"],
                 y_array=y_kwargs["array"],
                 x_attrs=x_kwargs["attrs"],
                 y_attrs=y_kwargs["attrs"],
+                x_key_dim=x_kwargs["key_dim"],
+                y_key_dim=y_kwargs["key_dim"],
                 buffer_bytes=buffer_bytes,
                 batch_size=batch_size,
                 shuffle_buffer_size=shuffle_buffer_size,
@@ -106,17 +116,19 @@ class TestPyTorchTileDBDataset:
                 assert len(unique_y_tensors) - 1 == i
 
     @parametrize_for_dataset(
-        # Add one extra row on X
+        # Add one extra key on X
         x_shape=((108, 10), (108, 10, 3)),
         y_shape=((107, 5), (107, 5, 2)),
     )
-    def test_unequal_num_rows(
+    def test_unequal_num_keys(
         self,
         tmpdir,
         x_shape,
         y_shape,
         x_sparse,
         y_sparse,
+        x_key_dim,
+        y_key_dim,
         num_attrs,
         pass_attrs,
         buffer_bytes,
@@ -125,9 +137,9 @@ class TestPyTorchTileDBDataset:
         num_workers,
     ):
         with ingest_in_tiledb(
-            tmpdir, x_shape, x_sparse, num_attrs, pass_attrs
+            tmpdir, x_shape, x_sparse, x_key_dim, num_attrs, pass_attrs
         ) as x_kwargs, ingest_in_tiledb(
-            tmpdir, y_shape, y_sparse, num_attrs, pass_attrs
+            tmpdir, y_shape, y_sparse, y_key_dim, num_attrs, pass_attrs
         ) as y_kwargs:
             with pytest.raises(ValueError) as ex:
                 PyTorchTileDBDataLoader(
@@ -135,6 +147,8 @@ class TestPyTorchTileDBDataset:
                     y_array=y_kwargs["array"],
                     x_attrs=x_kwargs["attrs"],
                     y_attrs=y_kwargs["attrs"],
+                    x_key_dim=x_kwargs["key_dim"],
+                    y_key_dim=y_kwargs["key_dim"],
                     buffer_bytes=buffer_bytes,
                     batch_size=batch_size,
                     shuffle_buffer_size=shuffle_buffer_size,
@@ -151,6 +165,8 @@ class TestPyTorchTileDBDataset:
         y_shape,
         x_sparse,
         y_sparse,
+        x_key_dim,
+        y_key_dim,
         num_attrs,
         pass_attrs,
         buffer_bytes,
@@ -160,15 +176,17 @@ class TestPyTorchTileDBDataset:
         csr,
     ):
         with ingest_in_tiledb(
-            tmpdir, x_shape, x_sparse, num_attrs, pass_attrs
+            tmpdir, x_shape, x_sparse, x_key_dim, num_attrs, pass_attrs
         ) as x_kwargs, ingest_in_tiledb(
-            tmpdir, y_shape, y_sparse, num_attrs, pass_attrs
+            tmpdir, y_shape, y_sparse, y_key_dim, num_attrs, pass_attrs
         ) as y_kwargs:
             dataloader = PyTorchTileDBDataLoader(
                 x_array=x_kwargs["array"],
                 y_array=y_kwargs["array"],
                 x_attrs=x_kwargs["attrs"],
                 y_attrs=y_kwargs["attrs"],
+                x_key_dim=x_kwargs["key_dim"],
+                y_key_dim=y_kwargs["key_dim"],
                 buffer_bytes=buffer_bytes,
                 batch_size=batch_size,
                 shuffle_buffer_size=shuffle_buffer_size,

--- a/tests/readers/test_tensorflow.py
+++ b/tests/readers/test_tensorflow.py
@@ -18,6 +18,8 @@ class TestTensorflowTileDBDataset:
         y_shape,
         x_sparse,
         y_sparse,
+        x_key_dim,
+        y_key_dim,
         num_attrs,
         pass_attrs,
         buffer_bytes,
@@ -26,15 +28,17 @@ class TestTensorflowTileDBDataset:
         num_workers,
     ):
         with ingest_in_tiledb(
-            tmpdir, x_shape, x_sparse, num_attrs, pass_attrs
+            tmpdir, x_shape, x_sparse, x_key_dim, num_attrs, pass_attrs
         ) as x_kwargs, ingest_in_tiledb(
-            tmpdir, y_shape, y_sparse, num_attrs, pass_attrs
+            tmpdir, y_shape, y_sparse, y_key_dim, num_attrs, pass_attrs
         ) as y_kwargs:
             dataset = TensorflowTileDBDataset(
                 x_array=x_kwargs["array"],
                 y_array=y_kwargs["array"],
                 x_attrs=x_kwargs["attrs"],
                 y_attrs=y_kwargs["attrs"],
+                x_key_dim=x_kwargs["key_dim"],
+                y_key_dim=y_kwargs["key_dim"],
                 buffer_bytes=buffer_bytes,
                 batch_size=batch_size,
                 shuffle_buffer_size=shuffle_buffer_size,
@@ -46,17 +50,19 @@ class TestTensorflowTileDBDataset:
             )
 
     @parametrize_for_dataset(
-        # Add one extra row on X
+        # Add one extra key on X
         x_shape=((108, 10), (108, 10, 3)),
         y_shape=((107, 5), (107, 5, 2)),
     )
-    def test_unequal_num_rows(
+    def test_unequal_num_keys(
         self,
         tmpdir,
         x_shape,
         y_shape,
         x_sparse,
         y_sparse,
+        x_key_dim,
+        y_key_dim,
         num_attrs,
         pass_attrs,
         buffer_bytes,
@@ -65,9 +71,9 @@ class TestTensorflowTileDBDataset:
         num_workers,
     ):
         with ingest_in_tiledb(
-            tmpdir, x_shape, x_sparse, num_attrs, pass_attrs
+            tmpdir, x_shape, x_sparse, x_key_dim, num_attrs, pass_attrs
         ) as x_kwargs, ingest_in_tiledb(
-            tmpdir, y_shape, y_sparse, num_attrs, pass_attrs
+            tmpdir, y_shape, y_sparse, y_key_dim, num_attrs, pass_attrs
         ) as y_kwargs:
             with pytest.raises(ValueError) as ex:
                 TensorflowTileDBDataset(
@@ -75,6 +81,8 @@ class TestTensorflowTileDBDataset:
                     y_array=y_kwargs["array"],
                     x_attrs=x_kwargs["attrs"],
                     y_attrs=y_kwargs["attrs"],
+                    x_key_dim=x_kwargs["key_dim"],
+                    y_key_dim=y_kwargs["key_dim"],
                     buffer_bytes=buffer_bytes,
                     batch_size=batch_size,
                     shuffle_buffer_size=shuffle_buffer_size,
@@ -90,6 +98,8 @@ class TestTensorflowTileDBDataset:
         y_shape,
         x_sparse,
         y_sparse,
+        x_key_dim,
+        y_key_dim,
         num_attrs,
         pass_attrs,
         buffer_bytes,
@@ -98,15 +108,17 @@ class TestTensorflowTileDBDataset:
         num_workers,
     ):
         with ingest_in_tiledb(
-            tmpdir, x_shape, x_sparse, num_attrs, pass_attrs
+            tmpdir, x_shape, x_sparse, x_key_dim, num_attrs, pass_attrs
         ) as x_kwargs, ingest_in_tiledb(
-            tmpdir, y_shape, y_sparse, num_attrs, pass_attrs
+            tmpdir, y_shape, y_sparse, y_key_dim, num_attrs, pass_attrs
         ) as y_kwargs:
             dataset = TensorflowTileDBDataset(
                 x_array=x_kwargs["array"],
                 y_array=y_kwargs["array"],
                 x_attrs=x_kwargs["attrs"],
                 y_attrs=y_kwargs["attrs"],
+                x_key_dim=x_kwargs["key_dim"],
+                y_key_dim=y_kwargs["key_dim"],
                 buffer_bytes=buffer_bytes,
                 batch_size=batch_size,
                 shuffle_buffer_size=shuffle_buffer_size,

--- a/tests/readers/test_tensorflow.py
+++ b/tests/readers/test_tensorflow.py
@@ -80,7 +80,7 @@ class TestTensorflowTileDBDataset:
                     shuffle_buffer_size=shuffle_buffer_size,
                     num_workers=num_workers,
                 )
-            assert "X and Y arrays must have the same number of rows" in str(ex.value)
+            assert "X and Y arrays have different keys" in str(ex.value)
 
     @parametrize_for_dataset(x_sparse=[True], shuffle_buffer_size=[0], num_workers=[0])
     def test_sparse_read_order(

--- a/tests/readers/utils.py
+++ b/tests/readers/utils.py
@@ -25,10 +25,10 @@ def parametrize_for_dataset(
     x_key_dim=(0, 1),
     y_key_dim=(0, 1),
     num_attrs=(1, 2),
-    pass_attrs=(True, False),
+    pass_attrs=(True,),
     buffer_bytes=(1024, None),
     batch_size=(8,),
-    shuffle_buffer_size=(0, 16),
+    shuffle_buffer_size=(16,),
     num_workers=(0, 2),
 ):
     argnames = [

--- a/tests/readers/utils.py
+++ b/tests/readers/utils.py
@@ -22,6 +22,8 @@ def parametrize_for_dataset(
     y_shape=((NUM_ROWS, 5), (NUM_ROWS, 5, 2)),
     x_sparse=(True, False),
     y_sparse=(True, False),
+    x_key_dim=(0, 1),
+    y_key_dim=(0, 1),
     num_attrs=(1, 2),
     pass_attrs=(True, False),
     buffer_bytes=(1024, None),
@@ -34,6 +36,8 @@ def parametrize_for_dataset(
         "y_shape",
         "x_sparse",
         "y_sparse",
+        "x_key_dim",
+        "y_key_dim",
         "num_attrs",
         "pass_attrs",
         "buffer_bytes",
@@ -46,6 +50,8 @@ def parametrize_for_dataset(
         y_shape,
         x_sparse,
         y_sparse,
+        x_key_dim,
+        y_key_dim,
         num_attrs,
         pass_attrs,
         buffer_bytes,
@@ -57,12 +63,14 @@ def parametrize_for_dataset(
 
 
 @contextmanager
-def ingest_in_tiledb(tmpdir, shape, sparse, num_attrs, pass_attrs):
+def ingest_in_tiledb(tmpdir, shape, sparse, key_dim, num_attrs, pass_attrs):
     """Context manager for ingesting data into TileDB."""
     array_uuid = str(uuid.uuid4())
     uri = os.path.join(tmpdir, array_uuid)
-    data = rand_array(shape, sparse)
     attrs = tuple(f"{array_uuid[0]}{i}" for i in range(num_attrs))
+    data = original_data = rand_array(shape, sparse)
+    if key_dim > 0:
+        data = np.moveaxis(data, 0, key_dim)
 
     dims = [
         tiledb.Dim(
@@ -90,7 +98,12 @@ def ingest_in_tiledb(tmpdir, shape, sparse, num_attrs, pass_attrs):
         tiledb_array[idx] = {attr: data[idx] for attr in attrs}
 
     with tiledb.open(uri) as array:
-        yield {"data": data, "array": array, "attrs": attrs if pass_attrs else ()}
+        yield {
+            "data": original_data,
+            "array": array,
+            "key_dim": key_dim,
+            "attrs": attrs if pass_attrs else (),
+        }
 
 
 def rand_array(shape: Sequence[int], sparse: bool = False) -> np.ndarray:

--- a/tiledb/ml/readers/_buffer_utils.py
+++ b/tiledb/ml/readers/_buffer_utils.py
@@ -1,87 +1,76 @@
 from math import ceil
-from typing import Optional, Sequence
+from typing import Optional
 
 import numpy as np
 
 import tiledb
 
+from ._tensor_gen import TensorSchema
+
 
 def get_buffer_size(
     array: tiledb.Array,
-    attrs: Sequence[str] = (),
+    schema: TensorSchema,
     memory_budget: Optional[int] = None,
-    start_offset: int = 0,
-    stop_offset: int = 0,
 ) -> int:
-    if not stop_offset:
-        stop_offset = array.shape[0]
+    """Estimate the minimum number of "rows" than can fit in the given memory budget.
+
+    A "row" is a slice along the `schema.key_dim_index` dimension where each cell consists
+    of the `schema.attrs` attributes.
+
+    :param array: TileDB array to read from.
+    :param schema: TensorSchema for the array.
+    :param memory_budget: The maximum amount of memory to use. This is bounded by
+        `tiledb.default_ctx().config()["sm.memory_budget"]`, which is also used as the
+        default memory_budget.
+    """
     if array.schema.sparse:
         # TODO: implement get_max_buffer_size() for sparse arrays
-        row_bytes = estimate_row_bytes(array, attrs, start_offset, stop_offset)
+        row_bytes = estimate_row_bytes(array, schema)
         buffer_size = (memory_budget or 100 * 1024**2) // row_bytes
     else:
-        buffer_size = get_max_buffer_size(array.schema, attrs, memory_budget)
+        buffer_size = get_max_buffer_size(array, schema, memory_budget)
     # clip the buffer size between 1 and total number of rows
-    return max(1, min(buffer_size, stop_offset - start_offset))
+    return max(1, min(buffer_size, schema.stop_key - schema.start_key))
 
 
-def estimate_row_bytes(
-    array: tiledb.Array,
-    attrs: Sequence[str] = (),
-    start_offset: int = 0,
-    stop_offset: int = 0,
-) -> int:
+def estimate_row_bytes(array: tiledb.Array, schema: TensorSchema) -> int:
     """
-    Estimate the size in bytes of a TileDB array row.
+    Estimate the size in bytes of a TileDB array "row".
 
-    A "row" is a slice with the first dimension fixed.
-    - For dense arrays, each row consists of a fixed number of cells. The size of each
-      cell depends on the given attributes (or all array attributes by default).
-    - For sparse arrays, each row consists of a variable number of non-empty cells. The
-      size of each non-empty cell depends on all dimension coordinates as well as the
-      given attributes (or all array attributes by default).
+    For dense arrays, each row consists of a fixed number of cells. The size of each
+    cell depends on `schema.attrs`.
+    For sparse arrays, each row consists of a variable number of non-empty cells. The
+    size of each non-empty cell depends on `schema.dims` and `schema.attrs`.
     """
-    schema = array.schema
-    if not attrs:
-        attrs = get_attr_names(schema)
-
-    if not schema.sparse:
+    if not array.schema.sparse:
         # for dense arrays the size of each row is fixed and can be computed exactly
         row_cells = np.prod(schema.shape[1:])
-        cell_bytes = sum(schema.attr(attr).dtype.itemsize for attr in attrs)
+        cell_bytes = sum(array.attr(attr).dtype.itemsize for attr in schema.attrs)
         est_row_bytes = row_cells * cell_bytes
     else:
         # for sparse arrays the size of each row is variable and can only be estimated
-        if not stop_offset:
-            stop_offset = schema.shape[0]
         query = array.query(return_incomplete=True)
-        # .multi_index[] is inclusive, so we need to subtract 1 to stop_offset
-        indexer = query.multi_index[start_offset : stop_offset - 1]
-        est_rs = indexer.estimated_result_sizes()
-        dims = get_dim_names(schema)
-        est_total_bytes = sum(est_rs[key].data_bytes for key in (*dims, *attrs))
-        est_row_bytes = est_total_bytes / (stop_offset - start_offset)
+        # .multi_index[] is inclusive, so we need to subtract 1 from stop_key
+        index_tuple = schema[schema.start_key : schema.stop_key - 1]
+        est_rs = query.multi_index[index_tuple].estimated_result_sizes()
+        est_total_bytes = sum(
+            est_rs[key].data_bytes for key in (*schema.dims, *schema.attrs)
+        )
+        est_row_bytes = est_total_bytes / (schema.stop_key - schema.start_key)
     return int(est_row_bytes)
 
 
 def get_max_buffer_size(
-    schema: tiledb.ArraySchema,
-    attrs: Sequence[str] = (),
+    array: tiledb.Array,
+    schema: TensorSchema,
     memory_budget: Optional[int] = None,
 ) -> int:
     """
     Get the maximum number of "rows" that can be read from an array with the given schema
     without incurring incomplete reads.
-
-    A "row" is a slice with the first dimension fixed.
-
-    :param schema: The array schema.
-    :param attrs: The attributes to read; defaults to all array attributes.
-    :param memory_budget: The maximum amount of memory to use. This is bounded by
-        `tiledb.default_ctx().config()["sm.memory_budget"]`, which is also used as the
-        default memory_budget.
     """
-    if schema.sparse:
+    if array.schema.sparse:
         raise NotImplementedError(
             "get_max_buffer_size() is not implemented for sparse arrays"
         )
@@ -91,38 +80,28 @@ def get_max_buffer_size(
         memory_budget = config_memory_budget
 
     # The memory budget should be large enough to read the cells of the largest attribute
-    if not attrs:
-        attrs = get_attr_names(schema)
-    bytes_per_cell = max(schema.attr(attr).dtype.itemsize for attr in attrs)
+    bytes_per_cell = max(array.attr(attr).dtype.itemsize for attr in schema.attrs)
 
     # We want to be reading tiles following the tile extents along each dimension.
     # The number of cells for each such tile is the product of all tile extents.
-    dim_tiles = tuple(int(schema.domain.dim(idx).tile) for idx in range(schema.ndim))
+    dim_tiles = [int(array.dim(dim).tile) for dim in schema.dims]
     cells_per_tile = np.prod(dim_tiles)
 
-    # Reading a slice of dim_tiles[0] rows requires reading a number of tiles that
+    # Each slice consists of `rows_per_slice` rows along the first `schema` dimension
+    rows_per_slice = dim_tiles[0]
+
+    # Reading a slice of `rows_per_slice` rows requires reading a number of tiles that
     # depends on the size and tile extent of each dimension after the first one.
     assert len(schema.shape) == len(dim_tiles)
     tiles_per_slice = np.prod(
-        tuple(
-            ceil(dim_size / dim_tile)
-            for dim_size, dim_tile in zip(schema.shape[1:], dim_tiles[1:])
-        )
+        [ceil(size / tile) for size, tile in zip(schema.shape[1:], dim_tiles[1:])]
     )
 
-    # Compute the size in bytes of each slice of dim_tiles[0] rows
+    # Compute the size in bytes of each slice of `rows_per_slice` rows
     bytes_per_slice = int(bytes_per_cell * cells_per_tile * tiles_per_slice)
 
     # Compute the number of slices that fit within the memory budget
     num_slices = memory_budget // bytes_per_slice
 
     # Compute the total number of rows to slice
-    return dim_tiles[0] * num_slices
-
-
-def get_attr_names(schema: tiledb.ArraySchema) -> Sequence[str]:
-    return tuple(schema.attr(idx).name for idx in range(schema.nattr))
-
-
-def get_dim_names(schema: tiledb.ArraySchema) -> Sequence[str]:
-    return tuple(schema.domain.dim(idx).name for idx in range(schema.ndim))
+    return rows_per_slice * num_slices

--- a/tiledb/ml/readers/_tensor_gen.py
+++ b/tiledb/ml/readers/_tensor_gen.py
@@ -1,11 +1,103 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from operator import itemgetter
-from typing import Callable, Generic, Iterator, Sequence, TypeVar, Union
+from typing import Callable, Generic, Iterator, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
 import sparse
 
 import tiledb
+
+
+class TensorSchema:
+    """
+    A class to encapsulate the information needed for mapping a TileDB array to tensors.
+    """
+
+    def __init__(
+        self,
+        schema: tiledb.ArraySchema,
+        key_dim: Union[int, str] = 0,
+        attrs: Sequence[str] = (),
+    ):
+        """
+        :param schema: Schema of the TileDB array to read from.
+        :param key_dim: Name or index of the key dimension; defaults to the first dimension.
+        :param attrs: Attribute names of array to read; defaults to all attributes.
+        """
+        shape = list(schema.shape)
+        dims = [schema.domain.dim(idx).name for idx in range(schema.ndim)]
+        if isinstance(key_dim, int):
+            key_dim_index = key_dim
+        else:
+            key_dim_index = dims.index(key_dim)
+        if key_dim_index > 0:
+            # Swap key dimension to first position
+            shape[0], shape[key_dim_index] = shape[key_dim_index], shape[0]
+            dims[0], dims[key_dim_index] = dims[key_dim_index], dims[0]
+
+        all_attrs = [schema.attr(idx).name for idx in range(schema.nattr)]
+        unknown_attrs = [attr for attr in attrs if attr not in all_attrs]
+        if unknown_attrs:
+            raise ValueError(f"Unknown attributes: {unknown_attrs}")
+
+        self._shape = tuple(shape)
+        self._dims = tuple(dims)
+        self._attrs = tuple(attrs or all_attrs)
+        self._key_bounds = tuple(map(int, schema.domain.dim(key_dim_index).domain))
+        self._leading_dim_slices = (slice(None),) * key_dim_index
+
+    @property
+    def attrs(self) -> Sequence[str]:
+        """The attribute names of the array to read."""
+        return self._attrs
+
+    @property
+    def dims(self) -> Sequence[str]:
+        """The dimension names of the array."""
+        return self._dims
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        """The shape of the array, with the key dimension moved first."""
+        return self._shape
+
+    @property
+    def key_dim_index(self) -> int:
+        """The index of the key dimension in the original TileDB schema."""
+        return len(self._leading_dim_slices)
+
+    @property
+    def start_key(self) -> int:
+        """The minimum value of the key dimension."""
+        return self._key_bounds[0]
+
+    @property
+    def stop_key(self) -> int:
+        """The maximum value of the key dimension, plus 1."""
+        return self._key_bounds[1] + 1
+
+    def __getitem__(self, key_dim_slice: slice) -> Tuple[slice, ...]:
+        """Return the indexing tuple for querying the TileDB array by `dim_key=key_dim_slice`.
+
+        For example, if `self.key_dim_index == 2`, then querying by the key dimension
+        would be `array[:, :, key_dim_slice]`, which corresponds to the indexing tuple
+        `(slice(None), slice(None), key_dim_slice)`.
+        """
+        return (*self._leading_dim_slices, key_dim_slice)
+
+    def ensure_equal_keys(self, other: TensorSchema) -> None:
+        """Ensure that the key dimension bounds of the of two schemas are equal.
+
+        :raises ValueError: If the key dimension bounds are not equal.
+        """
+        if self._key_bounds != other._key_bounds:
+            raise ValueError(
+                f"X and Y arrays have different keys: "
+                f"{self._key_bounds} != {other._key_bounds}"
+            )
+
 
 T = TypeVar("T")
 
@@ -13,22 +105,22 @@ T = TypeVar("T")
 class TileDBTensorGenerator(ABC, Generic[T]):
     """Generator of tensors read from a TileDB array."""
 
-    def __init__(self, array: tiledb.Array, attrs: Sequence[str]) -> None:
+    def __init__(self, array: tiledb.Array, schema: TensorSchema):
         """
         :param array: TileDB array to read from.
-        :param attrs: Attribute names of array to read.
+        :param schema: Tensor schema.
         """
         self._array = array
-        self._attrs = attrs
+        self._schema = schema
 
     @property
     def single_attr(self) -> bool:
         """Whether this generator reads a single attribute."""
-        return len(self._attrs) == 1
+        return len(self._schema.attrs) == 1
 
     @abstractmethod
     def iter_tensors(
-        self, buffer_size: int, start_offset: int, stop_offset: int
+        self, slice_size: int, start_key: int, stop_key: int
     ) -> Union[Iterator[T], Iterator[Sequence[T]]]:
         """
         Generate batches of tensors.
@@ -36,11 +128,11 @@ class TileDBTensorGenerator(ABC, Generic[T]):
         Each yielded batch is either:
         - a sequence of N tensors where `N == len(self.attrs)` if N > 1, or
         - a single tensor if N == 1.
-        Each tensor is a `T` instance of shape `(buffer_size, *self.array.shape[1:])`.
+        Each tensor is a `T` instance of shape `(slice_size, *self._schema.shape[1:])`.
 
-        :param buffer_size: Size of each slice of rows to read.
-        :param start_offset: Start row offset; defaults to 0.
-        :param stop_offset: Stop row offset; defaults to number of rows.
+        :param slice_size: Size of each slice along the key dimension.
+        :param start_key: Start value along the key dimension.
+        :param stop_key: Stop value along the key dimension.
         """
 
 
@@ -48,12 +140,24 @@ class TileDBNumpyGenerator(TileDBTensorGenerator[np.ndarray]):
     """Generator of Numpy arrays read from a TileDB array."""
 
     def iter_tensors(
-        self, buffer_size: int, start_offset: int, stop_offset: int
+        self, slice_size: int, start_key: int, stop_key: int
     ) -> Union[Iterator[np.ndarray], Iterator[Sequence[np.ndarray]]]:
-        query = self._array.query(attrs=self._attrs)
-        read_slices = iter_slices(start_offset, stop_offset, buffer_size)
-        buffers = map(query.__getitem__, read_slices)
-        return map(itemgetter(*self._attrs), buffers)
+        """
+        If `self._schema.key_dim index > 0`, the returned Numpy arrays will ve reshaped
+        so that the key_dim axes is first. For example, is the TileDB array `a` has shape
+        (5, 12, 20) and `key_dim_index==1`, the returned Numpy arrays of `a[:, 4:8, :]`
+        have shape (5, 4, 20) but this method returns arrays of shape (4, 5, 20).
+        """
+        query = self._array.query(attrs=self._schema.attrs)
+        get_data = itemgetter(*self._schema.attrs)
+        key_dim_index = self._schema.key_dim_index
+        for key_dim_slice in iter_slices(start_key, stop_key, slice_size):
+            attr_dict = query[self._schema[key_dim_slice]]
+            if key_dim_index > 0:
+                # Move key_dim_index axes first
+                for attr, array in attr_dict.items():
+                    attr_dict[attr] = np.moveaxis(array, key_dim_index, 0)
+            yield get_data(attr_dict)
 
 
 class TileDBSparseGenerator(TileDBTensorGenerator[T]):
@@ -62,28 +166,27 @@ class TileDBSparseGenerator(TileDBTensorGenerator[T]):
     def __init__(
         self,
         array: tiledb.Array,
-        attrs: Sequence[str],
+        schema: TensorSchema,
         from_coo: Callable[[sparse.COO], T],
-    ) -> None:
-        super().__init__(array, attrs)
+    ):
+        super().__init__(array, schema)
         self._from_coo = from_coo
-        self._dims = tuple(array.domain.dim(i).name for i in range(array.ndim))
 
     def iter_tensors(
-        self, buffer_size: int, start_offset: int, stop_offset: int
+        self, slice_size: int, start_key: int, stop_key: int
     ) -> Union[Iterator[T], Iterator[Sequence[T]]]:
-        shape = list(self._array.shape)
-        query = self._array.query(attrs=self._attrs)
-        get_coords = itemgetter(*self._dims)
-        get_data = itemgetter(*self._attrs)
+        shape = list(self._schema.shape)
+        query = self._array.query(attrs=self._schema.attrs)
+        get_coords = itemgetter(*self._schema.dims)
+        get_data = itemgetter(*self._schema.attrs)
         single_attr = self.single_attr
-        for read_slice in iter_slices(start_offset, stop_offset, buffer_size):
-            shape[0] = read_slice.stop - read_slice.start
-            buffer = query[read_slice]
-            coords = get_coords(buffer)
-            # normalize the first coordinate dimension to start at start_offset
-            np.subtract(coords[0], read_slice.start, out=coords[0])
-            data = get_data(buffer)
+        for key_dim_slice in iter_slices(start_key, stop_key, slice_size):
+            shape[0] = key_dim_slice.stop - key_dim_slice.start
+            attr_dict = query[self._schema[key_dim_slice]]
+            coords = get_coords(attr_dict)
+            # normalize the key dimension so that it starts at zero
+            np.subtract(coords[0], key_dim_slice.start, out=coords[0])
+            data = get_data(attr_dict)
             if single_attr:
                 yield self._from_coo(sparse.COO(coords, data, shape))
             else:


### PR DESCRIPTION
So far the key dimension for identifying each sample in the TileDB arrays is assumed to be the first. This PR relaxes this constraint by allowing any dimension to be used as the key dimension.

This is currently a draft. TODO items:
- Augment unit tests.
- Naming: the code so far refers to "rows", which is not a great name especially if the key dimension is not the first. The current PR introduces tentatively the term "key" dimension and derivatives (e.g. `key_dim`, `key_dim_index`) to refer to the identifying dimension. Other candidates could be `id_dim` or `sample_id_dim`. @georgeSkoumas @ktsitsi any preference or other suggestions?