### PR TITLE
Determine default buffer size for sparse arrays

### DIFF
--- a/tests/readers/test_buffer_utils.py
+++ b/tests/readers/test_buffer_utils.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 
 import tiledb
-from tiledb.ml.readers._buffer_utils import estimate_row_bytes, get_max_buffer_size
-from tiledb.ml.readers._tensor_gen import TensorSchema
+from tiledb.ml.readers._buffer_utils import get_buffer_size
+from tiledb.ml.readers._tensor_gen import TensorSchema, iter_slices
 
 
 @pytest.fixture
@@ -12,9 +12,9 @@ def dense_uri(tmp_path):
     schema = tiledb.ArraySchema(
         sparse=False,
         domain=tiledb.Domain(
-            tiledb.Dim(name="d0", domain=(0, 9999), dtype=np.uint32, tile=123),
-            tiledb.Dim(name="d1", domain=(1, 5), dtype=np.uint32, tile=2),
-            tiledb.Dim(name="d2", domain=(1, 2), dtype=np.uint32, tile=1),
+            tiledb.Dim(name="d0", domain=(0, 9999), dtype=np.int32, tile=123),
+            tiledb.Dim(name="d1", domain=(-2, 2), dtype=np.int32, tile=2),
+            tiledb.Dim(name="d2", domain=(1, 2), dtype=np.int32, tile=1),
         ),
         attrs=[
             tiledb.Attr(name="af8", dtype=np.float64),
@@ -24,25 +24,25 @@ def dense_uri(tmp_path):
     )
     tiledb.Array.create(uri, schema)
     with tiledb.open(uri, "w") as a:
-        size = a.schema.domain.size
         a[:] = {
-            "af8": np.random.rand(size),
-            "af4": np.random.rand(size).astype(np.float32),
-            "au1": np.random.randint(128, size=size, dtype=np.uint8),
+            "af8": np.random.rand(*schema.shape),
+            "af4": np.random.rand(*schema.shape).astype(np.float32),
+            "au1": np.random.randint(128, size=schema.shape, dtype=np.uint8),
         }
     return uri
 
 
 @pytest.fixture
-def sparse_uri(tmp_path):
+def sparse_uri(tmp_path, non_zero_per_row=3):
     uri = str(tmp_path / "sparse")
+    domains = [(1, 1000), (-250, 249), (0, 1)]
     schema = tiledb.ArraySchema(
         sparse=True,
         allows_duplicates=True,
         domain=tiledb.Domain(
-            tiledb.Dim(name="d0", domain=(0, 999), dtype=np.int32),
-            tiledb.Dim(name="d1", domain=(-250, 249), dtype=np.int32),
-            tiledb.Dim(name="d2", domain=(1, 10), dtype=np.int32),
+            tiledb.Dim(name="d0", domain=domains[0], dtype=np.uint32),
+            tiledb.Dim(name="d1", domain=domains[1], dtype=np.int16),
+            tiledb.Dim(name="d2", domain=domains[2], dtype=np.float64),
         ),
         attrs=[
             tiledb.Attr(name="af8", dtype=np.float64),
@@ -52,14 +52,12 @@ def sparse_uri(tmp_path):
     )
     tiledb.Array.create(uri, schema)
     with tiledb.open(uri, "w") as a:
-        num_rows = 1000
-        cells_per_row = 3
-        num_cells = num_rows * cells_per_row
         d0 = np.concatenate(
-            [np.arange(num_rows, dtype=np.uint32) for _ in range(cells_per_row)]
+            [np.arange(domains[0][0], domains[0][1] + 1)] * non_zero_per_row
         )
-        d1 = np.random.randint(-250, 250, num_cells).astype(np.int32)
-        d2 = np.random.randint(1, 11, num_cells).astype(np.uint16)
+        num_cells = len(d0)
+        d1 = np.random.randint(domains[1][0], domains[1][1] + 1, num_cells)
+        d2 = np.random.randint(domains[2][0], domains[2][1] + 1, num_cells)
         a[d0, d1, d2] = {
             "af8": np.random.rand(num_cells),
             "af4": np.random.rand(num_cells).astype(np.float32),
@@ -68,68 +66,59 @@ def sparse_uri(tmp_path):
     return uri
 
 
-@pytest.mark.parametrize("key_dim,row_cells", [(0, 10), (1, 20000), (2, 50000)])
-def test_estimate_row_bytes_dense(dense_uri, key_dim, row_cells):
-    with tiledb.open(dense_uri) as a:
-        # 8+4+1=13 bytes/cell
-        schema = TensorSchema(a.schema, key_dim)
-        assert estimate_row_bytes(a, schema) == row_cells * 13
-        # 8+1=9 bytes/cell
-        schema = TensorSchema(a.schema, key_dim, ["af8", "au1"])
-        assert estimate_row_bytes(a, schema) == row_cells * 9
-        # 4 bytes/cell
-        schema = TensorSchema(a.schema, key_dim, ["af4"])
-        assert estimate_row_bytes(a, schema) == row_cells * 4
-
-
-@pytest.mark.parametrize("key_dim,row_cells", [(0, 3), (1, 6), (2, 300)])
-def test_estimate_row_bytes_sparse(sparse_uri, key_dim, row_cells):
-    with tiledb.open(sparse_uri) as a:
-        # 3*4 bytes for dims + 8+4+1=13 bytes for attrs = 25 bytes/cell
-        schema = TensorSchema(a.schema, key_dim)
-        assert estimate_row_bytes(a, schema) == row_cells * 25
-        # 3*4 bytes for dims + 8+1=9 bytes for attrs = 21 bytes/cell
-        schema = TensorSchema(a.schema, key_dim, ["af8", "au1"])
-        assert estimate_row_bytes(a, schema) == row_cells * 21
-        # 3*4 bytes for dims + 4 bytes for attrs = 16 bytes/cell
-        schema = TensorSchema(a.schema, key_dim, ["af4"])
-        assert estimate_row_bytes(a, schema) == row_cells * 16
-
-
-@pytest.mark.parametrize(
+parametrize_attrs = pytest.mark.parametrize(
     "attrs",
     [(), ("af8",), ("af4",), ("au1",), ("af8", "af4"), ("af8", "au1"), ("af4", "au1")],
 )
+
+
 @pytest.mark.parametrize(
     "key_dim_index,memory_budget",
-    [
-        (0, 16_000),
-        (0, 32_000),
-        (0, 64_000),
-        (1, 500_000),
-        (1, 600_000),
-        (1, 700_000),
-    ],
+    [(0, 16_000), (0, 32_000), (0, 64_000), (1, 500_000), (1, 600_000), (1, 700_000)],
 )
-def test_get_max_buffer_size(dense_uri, attrs, key_dim_index, memory_budget):
-    config = {
-        "sm.memory_budget": memory_budget,
-        "py.max_incomplete_retries": 0,
-    }
-    with tiledb.scope_ctx(config), tiledb.open(dense_uri) as a:
+@parametrize_attrs
+def test_get_buffer_size_dense(dense_uri, attrs, key_dim_index, memory_budget):
+    config = {"py.max_incomplete_retries": 0, "sm.memory_budget": memory_budget}
+    with tiledb.open(dense_uri, config=config) as a:
         schema = TensorSchema(a.schema, key_dim_index, attrs)
-        buffer_size = get_max_buffer_size(a, schema)
-        # Check that the buffer size is a multiple of the row tile extent
-        assert buffer_size % a.dim(key_dim_index).tile == 0
-
-        # Check that we can slice with buffer_size without incomplete reads
-        offsets = range(schema.start_key, schema.stop_key, buffer_size)
+        buffer_size = get_buffer_size(a, schema)
         query = a.query(attrs=schema.attrs)
-        for offset in offsets:
-            query[schema[offset : offset + buffer_size]]
+        for key_slice in iter_slices(schema.start_key, schema.stop_key, buffer_size):
+            # query succeeds without incomplete retries
+            query.multi_index[schema[key_slice.start : key_slice.stop - 1]]
 
-        if buffer_size < a.shape[key_dim_index]:
-            # Check that buffer_size is the max size we can slice without incomplete reads
-            with pytest.raises(tiledb.TileDBError) as ex:
-                query[schema[offsets[0] : offsets[0] + buffer_size + 1]]
-            assert "py.max_incomplete_retries" in str(ex.value)
+            if key_slice.stop < schema.stop_key:
+                # querying a larger slice than buffer_size should fail
+                with pytest.raises(tiledb.TileDBError) as ex:
+                    query.multi_index[schema[key_slice]]
+                assert "py.max_incomplete_retries" in str(ex.value)
+
+
+@pytest.mark.parametrize(
+    "key_dim_index,memory_budget",
+    [(0, 1024), (0, 2048), (0, 4096), (1, 1024), (1, 2048), (1, 4096)],
+)
+@parametrize_attrs
+def test_get_buffer_size_sparse(sparse_uri, attrs, key_dim_index, memory_budget):
+    # The first dimension has a fixed number of non-zero cells per "row". The others
+    # don't, so the estimated buffer_size is not necessarily the maximum number of
+    # "rows" than can fit in the given memory budget. In this case relax the test by
+    # allowing 1 incomplete retry
+    exact = key_dim_index == 0
+    config = {
+        "py.max_incomplete_retries": 0 if exact else 1,
+        "py.init_buffer_bytes": memory_budget,
+    }
+    with tiledb.open(sparse_uri, config=config) as a:
+        schema = TensorSchema(a.schema, key_dim_index, attrs)
+        buffer_size = get_buffer_size(a, schema)
+        query = a.query(attrs=schema.attrs)
+        for key_slice in iter_slices(schema.start_key, schema.stop_key, buffer_size):
+            # query succeeds without incomplete retries (or at most 1 retry if not exact)
+            query.multi_index[schema[key_slice.start : key_slice.stop - 1]]
+
+            if exact and key_slice.stop < schema.stop_key:
+                # querying a larger slice than buffer_size should fail
+                with pytest.raises(tiledb.TileDBError) as ex:
+                    query.multi_index[schema[key_slice]]
+                assert "py.max_incomplete_retries" in str(ex.value)

--- a/tiledb/ml/readers/_buffer_utils.py
+++ b/tiledb/ml/readers/_buffer_utils.py
@@ -13,69 +13,56 @@ def get_buffer_size(
     schema: TensorSchema,
     memory_budget: Optional[int] = None,
 ) -> int:
-    """Estimate the minimum number of "rows" than can fit in the given memory budget.
+    """Estimate the maximum number of "rows" than can fit in the given memory budget.
 
     A "row" is a slice along the `schema.key_dim_index` dimension where each cell consists
     of the `schema.attrs` attributes.
 
     :param array: TileDB array to read from.
     :param schema: TensorSchema for the array.
-    :param memory_budget: The maximum amount of memory to use. This is bounded by
-        `tiledb.default_ctx().config()["sm.memory_budget"]`, which is also used as the
-        default memory_budget.
+    :param memory_budget: The maximum amount of memory to use. This is bounded by the
+        `sm.memory_budget` config parameter for dense arrays and `py.init_buffer_bytes`
+        (or 10 MB if unset) for sparse arrays. These bounds are also used as the default
+        memory budget.
     """
     if array.schema.sparse:
-        # TODO: implement get_max_buffer_size() for sparse arrays
-        row_bytes = estimate_row_bytes(array, schema)
-        buffer_size = (memory_budget or 100 * 1024**2) // row_bytes
+        buffer_size = _get_max_buffer_size_sparse(array, schema, memory_budget)
     else:
-        buffer_size = get_max_buffer_size(array, schema, memory_budget)
+        buffer_size = _get_max_buffer_size_dense(array, schema, memory_budget)
     # clip the buffer size between 1 and total number of rows
     return max(1, min(buffer_size, schema.stop_key - schema.start_key))
 
 
-def estimate_row_bytes(array: tiledb.Array, schema: TensorSchema) -> int:
-    """
-    Estimate the size in bytes of a TileDB array "row".
-
-    For dense arrays, each row consists of a fixed number of cells. The size of each
-    cell depends on `schema.attrs`.
-    For sparse arrays, each row consists of a variable number of non-empty cells. The
-    size of each non-empty cell depends on `schema.dims` and `schema.attrs`.
-    """
-    if not array.schema.sparse:
-        # for dense arrays the size of each row is fixed and can be computed exactly
-        row_cells = np.prod(schema.shape[1:])
-        cell_bytes = sum(array.attr(attr).dtype.itemsize for attr in schema.attrs)
-        est_row_bytes = row_cells * cell_bytes
-    else:
-        # for sparse arrays the size of each row is variable and can only be estimated
-        query = array.query(return_incomplete=True)
-        # .multi_index[] is inclusive, so we need to subtract 1 from stop_key
-        index_tuple = schema[schema.start_key : schema.stop_key - 1]
-        est_rs = query.multi_index[index_tuple].estimated_result_sizes()
-        est_total_bytes = sum(
-            est_rs[key].data_bytes for key in (*schema.dims, *schema.attrs)
-        )
-        est_row_bytes = est_total_bytes / (schema.stop_key - schema.start_key)
-    return int(est_row_bytes)
-
-
-def get_max_buffer_size(
+def _get_max_buffer_size_sparse(
     array: tiledb.Array,
     schema: TensorSchema,
     memory_budget: Optional[int] = None,
 ) -> int:
-    """
-    Get the maximum number of "rows" that can be read from an array with the given schema
-    without incurring incomplete reads.
-    """
-    if array.schema.sparse:
-        raise NotImplementedError(
-            "get_max_buffer_size() is not implemented for sparse arrays"
-        )
+    assert array.schema.sparse
+    try:
+        init_buffer_bytes = int(array._ctx_().config()["py.init_buffer_bytes"])
+    except KeyError:
+        init_buffer_bytes = 10 * 1024**2
+    if memory_budget is None or memory_budget > init_buffer_bytes:
+        memory_budget = init_buffer_bytes
 
-    config_memory_budget = int(tiledb.default_ctx().config()["sm.memory_budget"])
+    # the size of each row is variable and can only be estimated
+    query = array.query(attrs=schema.attrs, return_incomplete=True)
+    res_sizes = query.multi_index[:].estimated_result_sizes()
+
+    max_buffer_bytes = max(res_size.data_bytes for res_size in res_sizes.values())
+    max_bytes_per_row = max_buffer_bytes // (schema.stop_key - schema.start_key)
+
+    return int(memory_budget // max_bytes_per_row)
+
+
+def _get_max_buffer_size_dense(
+    array: tiledb.Array,
+    schema: TensorSchema,
+    memory_budget: Optional[int] = None,
+) -> int:
+    assert not array.schema.sparse
+    config_memory_budget = int(array._ctx_().config()["sm.memory_budget"])
     if memory_budget is None or memory_budget > config_memory_budget:
         memory_budget = config_memory_budget
 
@@ -84,7 +71,7 @@ def get_max_buffer_size(
 
     # We want to be reading tiles following the tile extents along each dimension.
     # The number of cells for each such tile is the product of all tile extents.
-    dim_tiles = [int(array.dim(dim).tile) for dim in schema.dims]
+    dim_tiles = [array.dim(dim).tile for dim in schema.dims]
     cells_per_tile = np.prod(dim_tiles)
 
     # Each slice consists of `rows_per_slice` rows along the first `schema` dimension
@@ -98,10 +85,10 @@ def get_max_buffer_size(
     )
 
     # Compute the size in bytes of each slice of `rows_per_slice` rows
-    bytes_per_slice = int(bytes_per_cell * cells_per_tile * tiles_per_slice)
+    bytes_per_slice = bytes_per_cell * cells_per_tile * tiles_per_slice
 
     # Compute the number of slices that fit within the memory budget
     num_slices = memory_budget // bytes_per_slice
 
     # Compute the total number of rows to slice
-    return rows_per_slice * num_slices
+    return int(rows_per_slice * num_slices)

--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -62,8 +62,10 @@ def PyTorchTileDBDataLoader(
     :param x_array: TileDB array of the features.
     :param y_array: TileDB array of the labels.
     :param batch_size: Size of each batch.
-    :param buffer_bytes: Maximum size (in bytes) of memory to allocate for reading
-        from each array (default=`tiledb.default_ctx().config()["sm.memory_budget"]`).
+    :param buffer_bytes: Maximum size (in bytes) of memory to allocate for reading from
+        each array. This is bounded by the `sm.memory_budget` config parameter of the
+        array context for dense arrays and `py.init_buffer_bytes` (or 10 MB if unset) for
+        sparse arrays. These bounds are also used as the default memory budget.
     :param shuffle_buffer_size: Number of elements from which this dataset will sample.
     :param prefetch: Number of samples loaded in advance by each worker. Not applicable
         (and should not be given) when `num_workers` is 0.

--- a/tiledb/ml/readers/tensorflow.py
+++ b/tiledb/ml/readers/tensorflow.py
@@ -39,7 +39,9 @@ def TensorflowTileDBDataset(
     :param y_array: TileDB array of the labels.
     :param batch_size: Size of each batch.
     :param buffer_bytes: Maximum size (in bytes) of memory to allocate for reading from
-        each array (default=`tiledb.default_ctx().config()["sm.memory_budget"]`).
+        each array. This is bounded by the `sm.memory_budget` config parameter of the
+        array context for dense arrays and `py.init_buffer_bytes` (or 10 MB if unset) for
+        sparse arrays. These bounds are also used as the default memory budget.
     :param shuffle_buffer_size: Number of elements from which this dataset will sample.
     :param prefetch: Maximum number of batches that will be buffered when prefetching.
         By default, the buffer size is dynamically tuned.


### PR DESCRIPTION
Improve the estimation of the maximum number of "rows" than can fit in the given memory budget for sparse arrays. Unlike the respective estimate for dense arrays, the sparse estimate is not exact: 
- It relies on [`est_result_size`](https://tiledb-inc-tiledb.readthedocs-hosted.com/en/stable/c++-api.html#_CPPv4NK6tiledb5Query15est_result_sizeERKNSt6stringE) which is not guaranteed to be accurate.
- Even if the estimated result size for the whole array is accurate, it assumes a uniform distribution of non-zero values along the "rows".

If both these conditions hold, the computed buffer size is correct as verified by the unit tests.

Other changes:
- Generalize `TensorSchema` to be defined for any TileDB array, not just those that support `.shape`. `TensorSchema.shape` is defined for any array with integer dimensions (even of different dtypes, e.g. uint8 and int32) and raises `ValueError` otherwise. This allows `get_buffer_size` to be defined for any dense or sparse TileDB array.
- Fix `get_buffer_size` to use the array context (instead of the default context).