### PR TITLE
Non-empty domain instead of full domain

### DIFF
--- a/tests/readers/test_buffer_utils.py
+++ b/tests/readers/test_buffer_utils.py
@@ -80,7 +80,7 @@ parametrize_attrs = pytest.mark.parametrize(
 def test_get_buffer_size_dense(dense_uri, attrs, key_dim_index, memory_budget):
     config = {"py.max_incomplete_retries": 0, "sm.memory_budget": memory_budget}
     with tiledb.open(dense_uri, config=config) as a:
-        schema = TensorSchema(a.schema, key_dim_index, attrs)
+        schema = TensorSchema(a, key_dim_index, attrs)
         buffer_size = get_buffer_size(a, schema)
         query = a.query(attrs=schema.attrs)
         for key_slice in iter_slices(schema.start_key, schema.stop_key, buffer_size):
@@ -110,7 +110,7 @@ def test_get_buffer_size_sparse(sparse_uri, attrs, key_dim_index, memory_budget)
         "py.init_buffer_bytes": memory_budget,
     }
     with tiledb.open(sparse_uri, config=config) as a:
-        schema = TensorSchema(a.schema, key_dim_index, attrs)
+        schema = TensorSchema(a, key_dim_index, attrs)
         buffer_size = get_buffer_size(a, schema)
         query = a.query(attrs=schema.attrs)
         for key_slice in iter_slices(schema.start_key, schema.stop_key, buffer_size):

--- a/tests/readers/test_pytorch.py
+++ b/tests/readers/test_pytorch.py
@@ -40,12 +40,8 @@ class TestPyTorchTileDBDataset:
             dataset = PyTorchTileDBDataset(
                 x_array=x_array,
                 y_array=y_array,
-                x_schema=TensorSchema(
-                    x_array.schema, x_kwargs["key_dim"], x_kwargs["attrs"]
-                ),
-                y_schema=TensorSchema(
-                    y_array.schema, y_kwargs["key_dim"], y_kwargs["attrs"]
-                ),
+                x_schema=TensorSchema(x_array, x_kwargs["key_dim"], x_kwargs["attrs"]),
+                y_schema=TensorSchema(y_array, y_kwargs["key_dim"], y_kwargs["attrs"]),
                 buffer_bytes=buffer_bytes,
             )
             assert isinstance(dataset, torch.utils.data.IterableDataset)
@@ -154,7 +150,7 @@ class TestPyTorchTileDBDataset:
                     shuffle_buffer_size=shuffle_buffer_size,
                     num_workers=num_workers,
                 )
-            assert "X and Y arrays have different keys" in str(ex.value)
+            assert "X and Y arrays have different key domain" in str(ex.value)
 
     @parametrize_for_dataset(x_sparse=[True], shuffle_buffer_size=[0], num_workers=[0])
     @pytest.mark.parametrize("csr", [True, False])

--- a/tests/readers/test_tensorflow.py
+++ b/tests/readers/test_tensorflow.py
@@ -88,7 +88,7 @@ class TestTensorflowTileDBDataset:
                     shuffle_buffer_size=shuffle_buffer_size,
                     num_workers=num_workers,
                 )
-            assert "X and Y arrays have different keys" in str(ex.value)
+            assert "X and Y arrays have different key domain" in str(ex.value)
 
     @parametrize_for_dataset(x_sparse=[True], shuffle_buffer_size=[0], num_workers=[0])
     def test_sparse_read_order(

--- a/tests/readers/utils.py
+++ b/tests/readers/utils.py
@@ -120,17 +120,16 @@ def rand_array(shape: Sequence[int], sparse: bool = False) -> np.ndarray:
     :param shape: Shape of the array.
     :param sparse:
       - If false, all values will be in the (0, 1) range.
-      - If true, only `shape[0]` values will be in the (0, 1) range, the rest will be 0.
-        Note: some rows may be all zeros.
+      - If true, only one value per row will be non-zero, the rest will be 0.
     """
-    if sparse:
-        a = np.zeros(shape)
-        flat_idxs = np.random.choice(a.size, size=len(a), replace=False)
-        a.flat[flat_idxs] = np.random.random(len(flat_idxs))
-    else:
-        a = np.random.random(shape)
-    assert a.shape == shape
-    return a
+    if not sparse:
+        return np.random.random(shape)
+
+    rows, cols = shape[0], np.prod(shape[1:])
+    a = np.zeros((rows, cols))
+    col_idxs = np.random.choice(cols, size=rows)
+    a[np.arange(rows), col_idxs] = np.random.random(rows)
+    return a.reshape(shape)
 
 
 def validate_tensor_generator(

--- a/tiledb/ml/readers/_buffer_utils.py
+++ b/tiledb/ml/readers/_buffer_utils.py
@@ -30,7 +30,7 @@ def get_buffer_size(
     else:
         buffer_size = _get_max_buffer_size_dense(array, schema, memory_budget)
     # clip the buffer size between 1 and total number of rows
-    return max(1, min(buffer_size, schema.stop_key - schema.start_key))
+    return max(1, min(buffer_size, schema.num_keys))
 
 
 def _get_max_buffer_size_sparse(
@@ -51,9 +51,9 @@ def _get_max_buffer_size_sparse(
     res_sizes = query.multi_index[:].estimated_result_sizes()
 
     max_buffer_bytes = max(res_size.data_bytes for res_size in res_sizes.values())
-    max_bytes_per_row = max_buffer_bytes // (schema.stop_key - schema.start_key)
+    max_bytes_per_row = ceil(max_buffer_bytes / schema.num_keys)
 
-    return int(memory_budget // max_bytes_per_row)
+    return memory_budget // max_bytes_per_row
 
 
 def _get_max_buffer_size_dense(

--- a/tiledb/ml/readers/_tensor_gen.py
+++ b/tiledb/ml/readers/_tensor_gen.py
@@ -76,6 +76,11 @@ class TensorSchema:
         return len(self._leading_dim_slices)
 
     @property
+    def num_keys(self) -> int:
+        """The number of distinct values along the key dimension"""
+        return self.stop_key - self.start_key
+
+    @property
     def start_key(self) -> int:
         """The minimum value of the key dimension."""
         return self._key_bounds[0]

--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -78,8 +78,8 @@ def PyTorchTileDBDataLoader(
         even if `shuffle_buffer_size` is zero when `num_workers` > 1.
     :param csr: For sparse 2D arrays, whether to return CSR tensors instead of COO.
     """
-    x_schema = TensorSchema(x_array.schema, x_key_dim, x_attrs)
-    y_schema = TensorSchema(y_array.schema, y_key_dim, y_attrs)
+    x_schema = TensorSchema(x_array, x_key_dim, x_attrs)
+    y_schema = TensorSchema(y_array, y_key_dim, y_attrs)
     return torch.utils.data.DataLoader(
         dataset=PyTorchTileDBDataset(
             x_array=x_array,
@@ -112,12 +112,12 @@ class PyTorchTileDBDataset(torch.utils.data.IterableDataset[XY]):
         super().__init__()
 
         if x_schema is None:
-            x_schema = TensorSchema(x_array.schema)
+            x_schema = TensorSchema(x_array)
         self._x_gen = _get_tensor_generator(x_array, x_schema)
         self._x_buffer_size = get_buffer_size(x_array, x_schema, buffer_bytes)
 
         if y_schema is None:
-            y_schema = TensorSchema(y_array.schema)
+            y_schema = TensorSchema(y_array)
         self._y_gen = _get_tensor_generator(y_array, y_schema)
         self._y_buffer_size = get_buffer_size(y_array, y_schema, buffer_bytes)
 

--- a/tiledb/ml/readers/tensorflow.py
+++ b/tiledb/ml/readers/tensorflow.py
@@ -53,11 +53,11 @@ def TensorflowTileDBDataset(
         used to fetch inputs asynchronously and in parallel. Note: yielded batches may
         be shuffled even if `shuffle_buffer_size` is zero when `num_workers` > 1.
     """
-    x_schema = TensorSchema(x_array.schema, x_key_dim, x_attrs)
+    x_schema = TensorSchema(x_array, x_key_dim, x_attrs)
     x_gen = _get_tensor_generator(x_array, x_schema)
     x_buffer_size = get_buffer_size(x_array, x_schema, buffer_bytes)
 
-    y_schema = TensorSchema(y_array.schema, y_key_dim, y_attrs)
+    y_schema = TensorSchema(y_array, y_key_dim, y_attrs)
     y_gen = _get_tensor_generator(y_array, y_schema)
     y_buffer_size = get_buffer_size(y_array, y_schema, buffer_bytes)
 


### PR DESCRIPTION
Currently the bounds of a dimension are based on the full dimension domain. This is accurate for dense arrays but it's an upper bound for sparse arrays; not all values in the full domain are necessarily present.

This PR replaces the full domain with the non-empty domain for determining the bounds of dimensions.
 
**Note**: Although the non-empty domain is an improvement over the full domain, it is still not accurate in general; not all values in the non-empty domain are necessarily present. Additionally, determining the number of unique values of the key dimension as `stop_key - start_key` works only for integer dimensions. These limitations are to be addressed in the future.

