### PR TITLE
InclusiveRange abstraction

### DIFF
--- a/tests/readers/test_ranges.py
+++ b/tests/readers/test_ranges.py
@@ -1,0 +1,257 @@
+import pickle
+from collections import Counter
+from datetime import timedelta
+
+import numpy as np
+import pytest
+
+from tiledb.ml.readers._ranges import InclusiveRange, IntRange, WeightedRange
+
+
+@pytest.mark.parametrize("values", [None, 42, 3.14])
+def test_inclusive_range_factory_type_error(values):
+    with pytest.raises(TypeError) as excinfo:
+        InclusiveRange.factory(values)
+    assert "Cannot create inclusive range" in str(excinfo.value)
+
+
+class TestIntRange:
+    values = range(10, 20)
+    r = InclusiveRange.factory(values)
+
+    def test_basic(self):
+        assert self.r.min == 10
+        assert self.r.max == 19
+        assert self.r.weight == 10
+        assert len(self.r) == 10
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            values,
+            list(values),
+            set(values),
+            iter(values),
+            reversed(values),
+            Counter(values),
+            np.array(values),
+            range(19, 9, -1),
+            np.arange(19, 9, -1),
+        ],
+    )
+    def test_equal(self, values):
+        assert_equal_ranges(self.r, InclusiveRange.factory(values), IntRange)
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            np.array(values, dtype=object),
+            range(0, 10),
+            range(10, 21),
+            range(11, 20),
+            range(10, 20, 2),
+        ],
+    )
+    def test_not_equal(self, values):
+        r = InclusiveRange.factory(values)
+        assert self.r != r
+        assert not self.r.equal_values(r)
+
+    @pytest.mark.parametrize(
+        "k,expected_bounds",
+        [
+            (1, [(10, 20)]),
+            (2, [(10, 15), (15, 20)]),
+            (3, [(10, 14), (14, 17), (17, 20)]),
+            (4, [(10, 13), (13, 16), (16, 18), (18, 20)]),
+            (5, [(10, 12), (12, 14), (14, 16), (16, 18), (18, 20)]),
+            (6, [(10, 12), (12, 14), (14, 16), (16, 18), (18, 19), (19, 20)]),
+            (7, [(10, 12), (12, 14), (14, 16)] + [(i, i + 1) for i in range(16, 20)]),
+            (8, [(10, 12), (12, 14)] + [(i, i + 1) for i in range(14, 20)]),
+            (9, [(10, 12)] + [(i, i + 1) for i in range(12, 20)]),
+            (10, [(i, i + 1) for i in range(10, 20)]),
+        ],
+    )
+    def test_partition_by_count(self, k, expected_bounds):
+        ranges = list(self.r.partition_by_count(k))
+        assert len(ranges) == k
+        expected_ranges = [InclusiveRange.factory(range(*bs)) for bs in expected_bounds]
+        assert ranges == expected_ranges
+
+    def test_partition_by_count_error(self):
+        for k in range(11, 20):
+            with pytest.raises(ValueError) as excinfo:
+                list(self.r.partition_by_count(k))
+            assert "Cannot partition range" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "max_weight,expected_bounds",
+        [
+            (1, [(i, i + 1) for i in range(10, 20)]),
+            (2, [(10, 12), (12, 14), (14, 16), (16, 18), (18, 20)]),
+            (3, [(10, 13), (13, 16), (16, 19), (19, 20)]),
+            (4, [(10, 14), (14, 18), (18, 20)]),
+            (5, [(10, 15), (15, 20)]),
+            (6, [(10, 16), (16, 20)]),
+            (7, [(10, 17), (17, 20)]),
+            (8, [(10, 18), (18, 20)]),
+            (9, [(10, 19), (19, 20)]),
+            (10, [(10, 20)]),
+            (11, [(10, 20)]),
+        ],
+    )
+    def test_partition_by_weight(self, max_weight, expected_bounds):
+        ranges = list(self.r.partition_by_weight(max_weight))
+        assert max(r.weight for r in ranges) <= max_weight
+        expected_ranges = [InclusiveRange.factory(range(*bs)) for bs in expected_bounds]
+        assert ranges == expected_ranges
+
+    def test_pickle(self):
+        assert pickle.loads(pickle.dumps(self.r)) == self.r
+
+
+class TestWeightedRange:
+    values = ("e", "f", "a", "d", "a", "c", "d", "a", "f", "c", "f", "f", "b", "d")
+    r = InclusiveRange.factory(values)
+    r2 = InclusiveRange.factory({v: timedelta(c) for v, c in Counter(values).items()})
+
+    @pytest.mark.parametrize("r", [r, r2])
+    def test_basic(self, r):
+        assert r.min == "a"
+        assert r.max == "f"
+        assert len(r) == 6
+        assert r.weight == 14 if r is self.r else timedelta(14)
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            values,
+            list(values),
+            iter(values),
+            reversed(values),
+            Counter(values),
+            np.array(values),
+            np.array(values, dtype=object),
+        ],
+    )
+    def test_equal(self, values):
+        assert_equal_ranges(self.r, InclusiveRange.factory(values), WeightedRange)
+
+    def test_not_equal(self):
+        assert self.r != InclusiveRange.factory(set(self.values))
+        assert self.r != InclusiveRange.factory(range(len(set(self.values))))
+
+    def test_equal_values(self):
+        assert self.r.equal_values(InclusiveRange.factory(set(self.values)))
+
+        r = InclusiveRange.factory([1, 2, 3, 3, 4, 5])
+        assert r.equal_values(InclusiveRange.factory(range(1, 6)))
+        assert not r.equal_values(InclusiveRange.factory(range(1, 7)))
+        assert not r.equal_values(InclusiveRange.factory(range(2, 7)))
+
+    def test_strided_range(self):
+        assert_equal_ranges(
+            InclusiveRange.factory(range(10, 20, 3)),
+            InclusiveRange.factory([10, 13, 16, 19]),
+            WeightedRange,
+        )
+        assert_equal_ranges(
+            InclusiveRange.factory(range(20, 10, -3)),
+            InclusiveRange.factory([11, 14, 17, 20]),
+            WeightedRange,
+        )
+
+    parametrize_by_count = pytest.mark.parametrize(
+        "k,expected_mappings",
+        [
+            (1, [{"e": 1, "f": 4, "a": 3, "d": 3, "c": 2, "b": 1}]),
+            (2, [{"b": 1, "c": 2, "a": 3}, {"e": 1, "f": 4, "d": 3}]),
+            (3, [{"b": 1, "a": 3}, {"c": 2, "d": 3}, {"e": 1, "f": 4}]),
+            (4, [{"a": 3}, {"b": 1, "c": 2}, {"d": 3, "e": 1}, {"f": 4}]),
+            (5, [{"a": 3}, {"b": 1, "c": 2}, {"d": 3}, {"e": 1}, {"f": 4}]),
+            (6, [{"a": 3}, {"b": 1}, {"c": 2}, {"d": 3}, {"e": 1}, {"f": 4}]),
+        ],
+    )
+
+    @parametrize_by_count
+    def test_partition_by_count(self, k, expected_mappings):
+        ranges = list(self.r.partition_by_count(k))
+        assert len(ranges) == k
+        expected_ranges = list(map(InclusiveRange.factory, expected_mappings))
+        assert ranges == expected_ranges
+
+    @parametrize_by_count
+    def test_partition_by_count2(self, k, expected_mappings):
+        ranges = list(self.r2.partition_by_count(k))
+        assert len(ranges) == k
+        expected_ranges = [
+            InclusiveRange.factory({v: timedelta(w) for v, w in mapping.items()})
+            for mapping in expected_mappings
+        ]
+        assert ranges == expected_ranges
+
+    @pytest.mark.parametrize("r", [r, r2])
+    def test_partition_by_count_error(self, r):
+        for k in range(7, 20):
+            with pytest.raises(ValueError) as excinfo:
+                list(r.partition_by_count(k))
+            assert "Cannot partition range" in str(excinfo.value)
+
+    parametrize_by_max_weight = pytest.mark.parametrize(
+        "max_weight,expected_mappings",
+        [
+            (4, [{"b": 1, "a": 3}, {"c": 2}, {"d": 3, "e": 1}, {"f": 4}]),
+            (5, [{"b": 1, "a": 3}, {"c": 2, "d": 3}, {"e": 1, "f": 4}]),
+            (6, [{"b": 1, "a": 3, "c": 2}, {"d": 3, "e": 1}, {"f": 4}]),
+            (7, [{"b": 1, "a": 3, "c": 2}, {"d": 3, "e": 1}, {"f": 4}]),
+            (8, [{"b": 1, "a": 3, "c": 2}, {"d": 3, "e": 1, "f": 4}]),
+            (9, [{"b": 1, "a": 3, "c": 2, "d": 3}, {"e": 1, "f": 4}]),
+            (10, [{"b": 1, "a": 3, "c": 2, "d": 3, "e": 1}, {"f": 4}]),
+            (11, [{"b": 1, "a": 3, "c": 2, "d": 3, "e": 1}, {"f": 4}]),
+            (12, [{"b": 1, "a": 3, "c": 2, "d": 3, "e": 1}, {"f": 4}]),
+            (13, [{"b": 1, "a": 3, "c": 2, "d": 3, "e": 1}, {"f": 4}]),
+            (14, [{"b": 1, "a": 3, "c": 2, "d": 3, "e": 1, "f": 4}]),
+            (15, [{"b": 1, "a": 3, "c": 2, "d": 3, "e": 1, "f": 4}]),
+        ],
+    )
+
+    @parametrize_by_max_weight
+    def test_partition_by_weight(self, max_weight, expected_mappings):
+        ranges = list(self.r.partition_by_weight(max_weight))
+        assert max(r.weight for r in ranges) <= max_weight
+        expected_ranges = list(map(InclusiveRange.factory, expected_mappings))
+        assert ranges == expected_ranges
+
+    @parametrize_by_max_weight
+    def test_partition_by_weight2(self, max_weight, expected_mappings):
+        max_weight = timedelta(max_weight)
+        ranges = list(self.r2.partition_by_weight(max_weight))
+        assert max(r.weight for r in ranges) <= max_weight
+        expected_ranges = [
+            InclusiveRange.factory({v: timedelta(w) for v, w in mapping.items()})
+            for mapping in expected_mappings
+        ]
+        assert ranges == expected_ranges
+
+    @pytest.mark.parametrize(
+        "r,max_weights", [(r, range(1, 4)), (r2, map(timedelta, range(1, 4)))]
+    )
+    def test_partition_by_weight_error(self, r, max_weights):
+        for max_weight in max_weights:
+            with pytest.raises(ValueError):
+                list(r.partition_by_weight(max_weight))
+
+    def test_pickle(self):
+        assert pickle.loads(pickle.dumps(self.r)) == self.r
+        assert pickle.loads(pickle.dumps(self.r2)) == self.r2
+
+
+def assert_equal_ranges(r1, r2, cls):
+    assert isinstance(r1, cls)
+    assert isinstance(r2, cls)
+    assert r1.min == r2.min
+    assert r1.max == r2.max
+    assert r1.weight == r2.weight
+    assert len(r1) == len(r2)
+    assert r1 == r2
+    assert r1.equal_values(r2)

--- a/tiledb/ml/readers/_ranges.py
+++ b/tiledb/ml/readers/_ranges.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import itertools as it
+from abc import ABC, abstractmethod
+from collections import Counter, abc
+from dataclasses import dataclass
+from functools import singledispatch
+from typing import Any, Generic, Iterable, Mapping, NoReturn, TypeVar, Union, cast
+
+import numpy as np
+
+__all__ = ["InclusiveRange"]
+
+V = TypeVar("V")
+W = TypeVar("W")
+VDtype = TypeVar("VDtype", bound=np.generic)
+WDtype = TypeVar("WDtype", bound=np.number)
+
+
+class InclusiveRange(ABC, Generic[V, W]):
+    """
+    Base abstract class for finite ranges that include both ends.
+
+    An InclusiveRange `R` is a sorted set of comparable elements of type `V`. Every member
+    `m` of `R` satisfies the inequality `R.min <= m <= R.max`.
+
+    As a set, an InclusiveRange does not contain duplicates. However, range members may
+    be associated with numeric weights of type `W`. This way duplicate members can be
+    represented as unique members with weight equal to the number of occurrences.
+    """
+
+    __slots__: Iterable[str] = ()
+
+    @property
+    @abstractmethod
+    def min(self) -> V:
+        """Lower bound of this range."""
+
+    @property
+    @abstractmethod
+    def max(self) -> V:
+        """Upper bound of this range."""
+
+    @property
+    @abstractmethod
+    def weight(self) -> W:
+        """Total weight of the members of this range."""
+
+    @property
+    @abstractmethod
+    def values(self) -> np.ndarray[V, Any]:
+        """Unique sorted values of this range."""
+
+    @abstractmethod
+    def __len__(self) -> int:
+        """Number of unique members in this range."""
+
+    @abstractmethod
+    def __eq__(self, other: Any) -> bool:
+        """Check if this range equals to another object.
+
+        Two ranges are equal if they consist of the same values with the same weights.
+        """
+
+    @abstractmethod
+    def equal_values(self, other: InclusiveRange[V, W]) -> bool:
+        """Check if two ranges consist of the same values."""
+
+    @abstractmethod
+    def partition_by_count(self, k: int) -> Iterable[InclusiveRange[V, W]]:
+        """Partition this range into `k` subranges of approximately equal weight."""
+
+    @abstractmethod
+    def partition_by_weight(self, max_weight: W) -> Iterable[InclusiveRange[V, W]]:
+        """
+        Partition this range into the minimum number of subranges so that each subrange
+        weight is at most `max_weight`.
+        """
+
+    @singledispatch
+    @staticmethod
+    def factory(values: Any) -> InclusiveRange[Any, Any]:
+        """Create an inclusive range of comparable values.
+
+        :param values: Can be:
+        - an integer `range`. The weight of each value is 1.
+        - an iterable of (potentially non-unique) values. The weight of each unique value
+          is its cardinality.
+        - a mapping from (unique) values to weights.
+        """
+
+    @staticmethod
+    @factory.register(range)
+    def _from_range(values: range) -> Union[IntRange, WeightedRange[np.int_, np.int_]]:
+        if values.step < 0:
+            values = range(values.stop + 1, values.start + 1, -values.step)
+
+        if values.step == 1:
+            return IntRange(values.start, values.stop - 1)
+        else:
+            return WeightedRange(
+                np.arange(values.start, values.stop, values.step),
+                np.ones(len(values), dtype=int),
+            )
+
+    @staticmethod
+    @factory.register(abc.Iterable)
+    def _from_iterable(values: Iterable[V]) -> Union[IntRange, InclusiveRange[V, int]]:
+        return InclusiveRange._from_mapping(Counter(values))
+
+    @staticmethod
+    @factory.register(abc.Mapping)
+    def _from_mapping(mapping: Mapping[V, W]) -> Union[IntRange, InclusiveRange[V, W]]:
+        unique_sorted, weights = zip(*sorted(mapping.items()))
+        return InclusiveRange._from_ndarrays(np.array(unique_sorted), np.array(weights))
+
+    @staticmethod
+    @factory.register(np.ndarray)
+    def _from_ndarray(
+        values: np.ndarray[VDtype, Any],
+    ) -> Union[IntRange, WeightedRange[VDtype, np.int_]]:
+        unique_sorted, counts = np.unique(values, return_counts=True)
+        return InclusiveRange._from_ndarrays(unique_sorted, counts)
+
+    @staticmethod
+    def _from_ndarrays(
+        unique_sorted: np.ndarray[VDtype, Any], weights: np.ndarray[WDtype, Any]
+    ) -> Union[IntRange, WeightedRange[VDtype, WDtype]]:
+        if (
+            np.issubsctype(unique_sorted, np.integer)
+            and unique_sorted[-1] - unique_sorted[0] + 1 == len(unique_sorted)
+            and np.all(weights == 1)
+        ):
+            return IntRange(unique_sorted[0].item(), unique_sorted[-1].item())
+        else:
+            return WeightedRange(unique_sorted, weights)
+
+    @staticmethod
+    @factory.register(object)
+    def _from_object(values: object) -> NoReturn:
+        raise TypeError(f"Cannot create inclusive range from {values!r}")
+
+    def __getstate__(self) -> Mapping[str, Any]:
+        return {slot: getattr(self, slot) for slot in self.__slots__}
+
+    def __setstate__(self, state: Mapping[str, Any]) -> None:
+        for slot, value in state.items():
+            object.__setattr__(self, slot, value)
+
+
+@dataclass(frozen=True)
+class IntRange(InclusiveRange[int, int]):
+    """
+    An inclusive range of consecutive integers.
+    """
+
+    __slots__ = ("min", "max")
+    min: int
+    max: int
+
+    def __post_init__(self) -> None:
+        assert self.min <= self.max
+
+    @property
+    def weight(self) -> int:
+        return len(self)
+
+    @property
+    def values(self) -> np.ndarray[int, Any]:
+        return np.arange(self.min, self.max + 1)
+
+    def __len__(self) -> int:
+        return self.max - self.min + 1
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, IntRange):
+            return NotImplemented
+        return self.min == other.min and self.max == other.max
+
+    def equal_values(self, other: InclusiveRange[V, W]) -> bool:
+        return self == other
+
+    def partition_by_count(self, k: int) -> Iterable[IntRange]:
+        n = len(self)
+        if not (1 <= k <= n):
+            raise ValueError(
+                f"Cannot partition range of {n} members into {k} partitions"
+            )
+        d, m = divmod(n, k)
+        # the first m partitions have length d+1 and the rest have length d
+        lengths = it.chain(it.repeat(d + 1, m), it.repeat(d, k - m))
+        yield from self._partition_by_lengths(lengths)
+
+    def partition_by_weight(self, max_weight: int) -> Iterable[IntRange]:
+        d, m = divmod(len(self), max_weight)
+        # all partitions have length max_weight, with the possible exception of the last
+        # partition that has length m (if m > 0)
+        lengths = it.chain(it.repeat(max_weight, d), it.repeat(m, m > 0))
+        yield from self._partition_by_lengths(lengths)
+
+    def _partition_by_lengths(self, lengths: Iterable[int]) -> Iterable[IntRange]:
+        start = self.min
+        for length in lengths:
+            next_start = start + length
+            yield IntRange(start, next_start - 1)
+            start = next_start
+
+
+@dataclass(frozen=True)
+class WeightedRange(InclusiveRange[VDtype, WDtype]):
+    """An inclusive range of weighted comparable values."""
+
+    __slots__ = ("values", "weights")
+    values: np.ndarray[VDtype, Any]
+    weights: np.ndarray[WDtype, Any]
+
+    def __post_init__(self) -> None:
+        assert self.values.ndim == self.weights.ndim == 1
+        assert len(self.values) == len(self.weights)
+
+    @property
+    def min(self) -> VDtype:
+        return cast(VDtype, self.values[0])
+
+    @property
+    def max(self) -> VDtype:
+        return cast(VDtype, self.values[-1])
+
+    @property
+    def weight(self) -> WDtype:
+        return cast(WDtype, np.sum(self.weights))
+
+    def __len__(self) -> int:
+        return len(self.values)
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, WeightedRange):
+            return NotImplemented
+        return bool(
+            len(self) == len(other)
+            and np.all(self.values == other.values)
+            and np.all(self.weights == other.weights)
+        )
+
+    def equal_values(self, other: InclusiveRange[V, W]) -> bool:
+        return bool(len(self) == len(other) and np.all(self.values == other.values))
+
+    def partition_by_count(self, k: int) -> Iterable[WeightedRange[VDtype, WDtype]]:
+        n = len(self)
+        if not (1 <= k <= n):
+            raise ValueError(
+                f"Cannot partition range of {n} members into {k} partitions"
+            )
+
+        values, weights = self.values, self.weights
+        if k == n:
+            # edge case: one partition per value
+            for i in range(n):
+                yield WeightedRange(values[i : i + 1], weights[i : i + 1])
+            return
+
+        total_weight = self.weight
+        # target_weight: sum of
+        # (a) weights of the partitions yielded so far and
+        # (b) the average of the remaining total weight over the remaining partitions
+        target_weight = total_weight / k
+        acc_weights = np.cumsum(weights)
+        start = 0
+        for i in range(k - 1, 0, -1):
+            # find the index of target_weight in the accumulated weights
+            stop = int(np.searchsorted(acc_weights, target_weight))
+            # check if it's after the start index; if not, move it right after start
+            if stop <= start < n:
+                stop = start + 1
+            # otherwise the following inequality holds:
+            # acc_weights[stop - 1] < target_weight <= acc_weights[stop]
+            elif (
+                acc_weights[stop] - target_weight
+                < target_weight - acc_weights[stop - 1]
+            ):
+                # increment stop if acc_weights[stop] is closer to target_weight than
+                # acc_weights[stop - 1]
+                stop += 1
+
+            # yield partition
+            yield WeightedRange(values[start:stop], weights[start:stop])
+
+            # update target_weight and start index
+            target_weight = acc_weights[stop - 1]
+            target_weight += (total_weight - target_weight) / i
+            start = stop
+
+        # yield last partition
+        yield WeightedRange(values[start:], weights[start:])
+
+    def partition_by_weight(
+        self, max_weight: WDtype
+    ) -> Iterable[WeightedRange[VDtype, WDtype]]:
+        values, weights = self.values, self.weights
+        if max_weight < np.max(weights):
+            raise ValueError(
+                f"Cannot partition range with max weight={max_weight}: "
+                f"max value weight={np.max(weights)}"
+            )
+        # target_weight: sum of weights of the partitions yielded so far plus max_weight
+        target_weight = max_weight
+        acc_weights = np.cumsum(weights)
+        start = 0
+        n = len(acc_weights)
+        while start < n:
+            # find the index of target_weight in the accumulated weights
+            stop = int(np.searchsorted(acc_weights, target_weight, side="right"))
+            # yield partition
+            yield WeightedRange(values[start:stop], weights[start:stop])
+            # update target_weight and start index
+            target_weight = acc_weights[stop - 1] + max_weight
+            start = stop


### PR DESCRIPTION
Currently TileDB-ML data loaders support only integer dimensions of consecutive integers (`int ranges`) as the key dimension (`x_key_dim`/`y_key_dim`). This PR paves the way for allowing any TileDB-supported dimension to be specified as key dimension by introducing `InclusiveRange`.

**`InclusiveRange`** is a generic abstract class that represents a finite set of comparable elements. Additionally, each member of the range `r`  is associated with a numeric weight. The main properties and methods of an `InclusiveRange` are the following:
- `r.min`: The minimum element of the range. 
- `r.max`: The maximum element of the range.
- `r.weight`: The cumulative weight of the members of the range.
- `len(r)`: The number of (unique) elements of the range.
- `r.partition_by_count(k)`: Partition `r` into `k` subranges of approximately equal weight.
- `r.partition_by_weight(w)`: Partition `r` into the minimum number of subranges so that `s.weight <= w` for each subrange `s`.

Two concrete subclasses of `InclusiveRange` are implemented: 
- `IntRange`: represents the consecutive integers between `min` and `max` (inclusive) with all weights equal to 1.
- `WeightedRange[V, W]`: represents any range of values of type `V` with weights of type `W`.

These concrete subclasses are not intended to be instantiated directly by the user. Instead, all ranges are to be created via the `InclusiveRange.factory(values)` static method, where `values` can be:
- a mapping from (unique) values to weights.
- an iterable of (potentially non-unique) values. The weight of each unique value is its cardinality.
