### PR TITLE
Support non-integer key dimension

### DIFF
--- a/tests/readers/test_pytorch.py
+++ b/tests/readers/test_pytorch.py
@@ -18,6 +18,7 @@ class TestPyTorchTileDBDataLoader:
         y_shape,
         x_sparse,
         y_sparse,
+        key_dim_dtype,
         x_key_dim,
         y_key_dim,
         num_fields,
@@ -29,9 +30,9 @@ class TestPyTorchTileDBDataLoader:
             pytest.skip("multiple workers not supported with sparse arrays")
 
         with ingest_in_tiledb(
-            tmpdir, x_shape, x_sparse, x_key_dim, num_fields
+            tmpdir, x_shape, x_sparse, key_dim_dtype, x_key_dim, num_fields
         ) as x_kwargs, ingest_in_tiledb(
-            tmpdir, y_shape, y_sparse, y_key_dim, num_fields
+            tmpdir, y_shape, y_sparse, key_dim_dtype, y_key_dim, num_fields
         ) as y_kwargs:
             dataloader = PyTorchTileDBDataLoader(
                 x_array=x_kwargs["array"],
@@ -61,6 +62,7 @@ class TestPyTorchTileDBDataLoader:
         y_shape,
         x_sparse,
         y_sparse,
+        key_dim_dtype,
         x_key_dim,
         y_key_dim,
         num_fields,
@@ -69,9 +71,9 @@ class TestPyTorchTileDBDataLoader:
         num_workers,
     ):
         with ingest_in_tiledb(
-            tmpdir, x_shape, x_sparse, x_key_dim, num_fields
+            tmpdir, x_shape, x_sparse, key_dim_dtype, x_key_dim, num_fields
         ) as x_kwargs, ingest_in_tiledb(
-            tmpdir, y_shape, y_sparse, y_key_dim, num_fields
+            tmpdir, y_shape, y_sparse, key_dim_dtype, y_key_dim, num_fields
         ) as y_kwargs:
             with pytest.raises(ValueError) as ex:
                 PyTorchTileDBDataLoader(
@@ -96,6 +98,7 @@ class TestPyTorchTileDBDataLoader:
         y_shape,
         x_sparse,
         y_sparse,
+        key_dim_dtype,
         x_key_dim,
         y_key_dim,
         num_fields,
@@ -110,9 +113,9 @@ class TestPyTorchTileDBDataLoader:
         no shuffling (shuffle_buffer_size=0).
         """
         with ingest_in_tiledb(
-            tmpdir, x_shape, x_sparse, x_key_dim, num_fields
+            tmpdir, x_shape, x_sparse, key_dim_dtype, x_key_dim, num_fields
         ) as x_kwargs, ingest_in_tiledb(
-            tmpdir, y_shape, y_sparse, y_key_dim, num_fields
+            tmpdir, y_shape, y_sparse, key_dim_dtype, y_key_dim, num_fields
         ) as y_kwargs:
             dataloader = PyTorchTileDBDataLoader(
                 x_array=x_kwargs["array"],

--- a/tests/readers/test_ranges.py
+++ b/tests/readers/test_ranges.py
@@ -57,6 +57,25 @@ class TestIntRange:
         assert self.r != r
         assert not self.r.equal_values(r)
 
+    def test_indices(self):
+        np.testing.assert_array_equal(
+            self.r.indices(np.array([10, 16, 16, 11, 19, 11])),
+            np.array([0, 6, 6, 1, 9, 1]),
+        )
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            [10, 16, 16, 11, 20],
+            [10, 16, 16, 11, 9],
+            [10, 16, 16, 11, 15.5],
+        ],
+    )
+    def test_indices_error(self, values):
+        with pytest.raises(ValueError) as excinfo:
+            self.r.indices(np.array(values))
+        assert "Values not in the range" in str(excinfo.value)
+
     @pytest.mark.parametrize(
         "k,expected_bounds",
         [
@@ -160,6 +179,25 @@ class TestWeightedRange:
             InclusiveRange.factory([11, 14, 17, 20]),
             WeightedRange,
         )
+
+    def test_indices(self):
+        np.testing.assert_array_equal(
+            self.r.indices(np.array(["a", "e", "e", "d", "a", "f", "c"])),
+            np.array([0, 4, 4, 3, 0, 5, 2]),
+        )
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            ["a", "e", "e", "d", "_"],
+            ["a", "e", "e", "d", "z"],
+            ["a", "e", "e", "d", "aa"],
+        ],
+    )
+    def test_indices_error(self, values):
+        with pytest.raises(ValueError) as excinfo:
+            self.r.indices(np.array(values))
+        assert "Values not in the range" in str(excinfo.value)
 
     parametrize_by_count = pytest.mark.parametrize(
         "k,expected_mappings",

--- a/tests/readers/test_tensorflow.py
+++ b/tests/readers/test_tensorflow.py
@@ -18,6 +18,7 @@ class TestTensorflowTileDBDataset:
         y_shape,
         x_sparse,
         y_sparse,
+        key_dim_dtype,
         x_key_dim,
         y_key_dim,
         num_fields,
@@ -26,9 +27,9 @@ class TestTensorflowTileDBDataset:
         num_workers,
     ):
         with ingest_in_tiledb(
-            tmpdir, x_shape, x_sparse, x_key_dim, num_fields
+            tmpdir, x_shape, x_sparse, key_dim_dtype, x_key_dim, num_fields
         ) as x_kwargs, ingest_in_tiledb(
-            tmpdir, y_shape, y_sparse, y_key_dim, num_fields
+            tmpdir, y_shape, y_sparse, key_dim_dtype, y_key_dim, num_fields
         ) as y_kwargs:
             dataset = TensorflowTileDBDataset(
                 x_array=x_kwargs["array"],
@@ -58,6 +59,7 @@ class TestTensorflowTileDBDataset:
         y_shape,
         x_sparse,
         y_sparse,
+        key_dim_dtype,
         x_key_dim,
         y_key_dim,
         num_fields,
@@ -66,9 +68,9 @@ class TestTensorflowTileDBDataset:
         num_workers,
     ):
         with ingest_in_tiledb(
-            tmpdir, x_shape, x_sparse, x_key_dim, num_fields
+            tmpdir, x_shape, x_sparse, key_dim_dtype, x_key_dim, num_fields
         ) as x_kwargs, ingest_in_tiledb(
-            tmpdir, y_shape, y_sparse, y_key_dim, num_fields
+            tmpdir, y_shape, y_sparse, key_dim_dtype, y_key_dim, num_fields
         ) as y_kwargs:
             with pytest.raises(ValueError) as ex:
                 TensorflowTileDBDataset(
@@ -92,6 +94,7 @@ class TestTensorflowTileDBDataset:
         y_shape,
         x_sparse,
         y_sparse,
+        key_dim_dtype,
         x_key_dim,
         y_key_dim,
         num_fields,
@@ -105,9 +108,9 @@ class TestTensorflowTileDBDataset:
         no shuffling (shuffle_buffer_size=0).
         """
         with ingest_in_tiledb(
-            tmpdir, x_shape, x_sparse, x_key_dim, num_fields
+            tmpdir, x_shape, x_sparse, key_dim_dtype, x_key_dim, num_fields
         ) as x_kwargs, ingest_in_tiledb(
-            tmpdir, y_shape, y_sparse, y_key_dim, num_fields
+            tmpdir, y_shape, y_sparse, key_dim_dtype, y_key_dim, num_fields
         ) as y_kwargs:
             dataset = TensorflowTileDBDataset(
                 x_array=x_kwargs["array"],


### PR DESCRIPTION
Add support for non-integer key dimension for sparse arrays.

The current implementation requires a full scan of the array along the key dimension to collect all the unique keys along with the respective non-empty cell count for each key. When/if the [TileDB internal partitioner is exposed](https://github.com/TileDB-Inc/TileDB/pull/2664), a more efficient partitioning may be implemented.