### PR TITLE
Decouple transform from TensorSchema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
         "local_scheme": "dirty-tag",
         "write_to": "tiledb/ml/version.py",
     },
-    install_requires=["sparse", "tiledb>=0.14"],
+    install_requires=["sparse", "tiledb>=0.14", "wrapt"],
     extras_require={
         "tensorflow": tensorflow,
         "pytorch": pytorch,

--- a/tiledb/ml/readers/_tensor_schema.py
+++ b/tiledb/ml/readers/_tensor_schema.py
@@ -86,11 +86,6 @@ class TensorSchema(ABC):
 
     @property
     @abstractmethod
-    def sparse(self) -> bool:
-        """Whether the underlying TileDB array is sparse"""
-
-    @property
-    @abstractmethod
     def key_range(self) -> InclusiveRange[Any, int]:
         """Inclusive range of the key dimension.
 
@@ -130,8 +125,6 @@ class TensorSchema(ABC):
 
 
 class DenseTensorSchema(TensorSchema):
-    sparse = False
-
     @property
     def key_range(self) -> InclusiveRange[int, int]:
         key_dim_min, key_dim_max = self._ned[0]
@@ -192,7 +185,6 @@ class DenseTensorSchema(TensorSchema):
 
 
 class SparseTensorSchema(TensorSchema):
-    sparse = True
 
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)

--- a/tiledb/ml/readers/tensorflow.py
+++ b/tiledb/ml/readers/tensorflow.py
@@ -65,7 +65,9 @@ TensorSpec = Union[tf.TensorSpec, tf.SparseTensorSpec]
 
 
 def _get_tensor_specs(schema: TensorSchema) -> Union[TensorSpec, Sequence[TensorSpec]]:
-    cls = tf.SparseTensorSpec if schema.sparse else tf.TensorSpec
+    cls = (
+        tf.SparseTensorSpec if isinstance(schema, SparseTensorSchema) else tf.TensorSpec
+    )
     shape = (None, *schema.shape[1:])
     specs = tuple(cls(shape=shape, dtype=dtype) for dtype in schema.field_dtypes)
     return specs if len(specs) > 1 else specs[0]

--- a/tiledb/ml/readers/types.py
+++ b/tiledb/ml/readers/types.py
@@ -1,9 +1,7 @@
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Sequence, TypeVar, Union
+from typing import Any, Mapping, Sequence, Union
 
 import tiledb
-
-Tensor = TypeVar("Tensor")
 
 
 @dataclass(frozen=True)
@@ -11,7 +9,7 @@ class ArrayParams:
     array: tiledb.Array
     key_dim: Union[int, str] = 0
     fields: Sequence[str] = ()
-    _tensor_schema_kwargs: Mapping[str, Any] = field(init=False, repr=False)
+    tensor_schema_kwargs: Mapping[str, Any] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         all_attrs = [self.array.attr(i).name for i in range(self.array.nattr)]
@@ -42,15 +40,12 @@ class ArrayParams:
             all_dims[0], all_dims[key_dim_index] = all_dims[key_dim_index], all_dims[0]
             ned[0], ned[key_dim_index] = ned[key_dim_index], ned[0]
 
-        object.__setattr__(
-            self,
-            "_tensor_schema_kwargs",
-            dict(
-                array=self.array,
-                fields=tuple(final_fields),
-                key_dim_index=key_dim_index,
-                ned=tuple(ned),
-                all_dims=tuple(all_dims),
-                query_kwargs={"attrs": tuple(attrs), "dims": tuple(dims)},
-            ),
+        tensor_schema_kwargs = dict(
+            _array=self.array,
+            _key_dim_index=key_dim_index,
+            _fields=tuple(final_fields),
+            _all_dims=tuple(all_dims),
+            _ned=tuple(ned),
+            _query_kwargs={"attrs": tuple(attrs), "dims": tuple(dims)},
         )
+        object.__setattr__(self, "tensor_schema_kwargs", tensor_schema_kwargs)


### PR DESCRIPTION
Move the (optional) reader transform/map logic out of the base `TensorSchema` to a separate `MappedTensorSchema` proxy class.

Also did two minor internal `TensorSchema` changes:
- Drop `TensorSchema.sparse` property
- Make `SparseTensorSchema.key_range` (effectively) a cached property that caches the key_range the first time it is computed.