### PR TITLE
Add ArrayParams.tensor_kind

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
         "local_scheme": "dirty-tag",
         "write_to": "tiledb/ml/version.py",
     },
-    install_requires=["sparse", "tiledb>=0.14"],
+    install_requires=["sparse", "tiledb>=0.14", "wrapt"],
     extras_require={
         "tensorflow": tensorflow,
         "pytorch": pytorch,

--- a/tests/readers/test_pytorch.py
+++ b/tests/readers/test_pytorch.py
@@ -96,7 +96,6 @@ class TestPyTorchTileDBDataLoader:
             assert "All arrays must have the same key range" in str(ex.value)
 
     @parametrize_for_dataset(num_fields=[0], shuffle_buffer_size=[0], num_workers=[0])
-    @pytest.mark.parametrize("csr", [True, False])
     def test_dataloader_order(
         self,
         tmpdir,
@@ -111,7 +110,6 @@ class TestPyTorchTileDBDataLoader:
         batch_size,
         shuffle_buffer_size,
         num_workers,
-        csr,
     ):
         """Test we can read the data in the same order as written.
 
@@ -134,7 +132,6 @@ class TestPyTorchTileDBDataLoader:
                 ArrayParams(y_kwargs["array"], y_kwargs["key_dim"], y_kwargs["fields"]),
                 **dataloader_params,
                 shuffle_buffer_size=shuffle_buffer_size,
-                csr=csr,
             )
             # since num_fields is 0, fields are all the array attributes of each array
             # the first item of each batch corresponds to the first attribute (="data")

--- a/tests/readers/test_tensor_schema.py
+++ b/tests/readers/test_tensor_schema.py
@@ -5,7 +5,6 @@ import numpy as np
 import pytest
 
 import tiledb
-from tiledb.ml.readers._tensor_schema import DenseTensorSchema, SparseTensorSchema
 from tiledb.ml.readers.types import ArrayParams
 
 
@@ -96,8 +95,7 @@ def parametrize_fields(*fields):
 def test_max_partition_weight_dense(dense_uri, fields, key_dim_index, memory_budget):
     config = {"py.max_incomplete_retries": 0, "sm.memory_budget": memory_budget}
     with tiledb.open(dense_uri, config=config) as a:
-        params = ArrayParams(a, key_dim_index, fields)
-        schema = DenseTensorSchema.from_array_params(params)
+        schema = ArrayParams(a, key_dim_index, fields).to_tensor_schema()
         max_weight = schema.max_partition_weight
         for key_range in schema.key_range.partition_by_weight(max_weight):
             # query succeeds without incomplete retries
@@ -120,8 +118,7 @@ def test_max_partition_weight_sparse(sparse_uri, fields, key_dim_index, memory_b
     }
     with tiledb.open(sparse_uri, config=config) as a:
         key_dim = a.dim(key_dim_index)
-        params = ArrayParams(a, key_dim_index, fields)
-        schema = SparseTensorSchema.from_array_params(params)
+        schema = ArrayParams(a, key_dim_index, fields).to_tensor_schema()
         max_weight = schema.max_partition_weight
         for key_range in schema.key_range.partition_by_weight(max_weight):
             # query succeeds without incomplete retries

--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -2,7 +2,6 @@
 
 import itertools
 import random
-from operator import methodcaller
 from typing import (
     Any,
     Callable,
@@ -21,7 +20,7 @@ import sparse
 import torch
 from torch.utils.data import DataLoader, IterableDataset, get_worker_info
 
-from ._tensor_schema import DenseTensorSchema, SparseTensorSchema, TensorSchema
+from ._tensor_schema import TensorKind, TensorSchema
 from .types import ArrayParams
 
 Tensor = Union[np.ndarray, sparse.COO, scipy.sparse.csr_matrix]
@@ -33,13 +32,13 @@ OneOrMoreTensorsOrSequences = Union[TensorOrSequence, Tuple[TensorOrSequence, ..
 
 
 def PyTorchTileDBDataLoader(
-    *array_params: ArrayParams,
+    *all_array_params: ArrayParams,
     shuffle_buffer_size: int = 0,
     **kwargs: Dict[str, Any],
 ) -> DataLoader:
     """Return a DataLoader for loading data from TileDB arrays.
 
-    :param array_params: One or more `ArrayParams` instances, one per TileDB array.
+    :param all_array_params: One or more `ArrayParams` instances, one per TileDB array.
     :param shuffle_buffer_size: Number of elements from which this dataset will sample.
     **kwargs: Should contain all parameters for PyTorch Dataloader. At the moment TileDB-ML can support ONLY the
     following PyTorch Dataloader arguments:
@@ -59,7 +58,9 @@ def PyTorchTileDBDataLoader(
     Users should NOT pass (TileDB-ML either doesn't support or implements internally the corresponding functionality)
     the following arguments: 'shuffle', 'sampler', 'batch_sampler', 'worker_init_fn' and 'collate_fn'.
     """
-    schemas = tuple(map(_get_tensor_schema, array_params))
+    schemas = tuple(
+        array_params.to_tensor_schema() for array_params in all_array_params
+    )
     collators = tuple(map(_get_tensor_collator, schemas))
     collate_fn = _CompositeCollator(*collators) if len(collators) > 1 else collators[0]
 
@@ -72,7 +73,9 @@ def PyTorchTileDBDataLoader(
 
 
 class _PyTorchTileDBDataset(IterableDataset[OneOrMoreTensorsOrSequences]):
-    def __init__(self, schemas: Sequence[TensorSchema], shuffle_buffer_size: int = 0):
+    def __init__(
+        self, schemas: Sequence[TensorSchema[Tensor]], shuffle_buffer_size: int = 0
+    ):
         super().__init__()
         key_range = schemas[0].key_range
         if not all(key_range.equal_values(schema.key_range) for schema in schemas[1:]):
@@ -82,17 +85,16 @@ class _PyTorchTileDBDataset(IterableDataset[OneOrMoreTensorsOrSequences]):
         self._shuffle_buffer_size = shuffle_buffer_size
 
     def __iter__(self) -> Iterator[OneOrMoreTensorsOrSequences]:
-        rows: Iterator[OneOrMoreTensorsOrSequences]
         it_rows = tuple(map(self._iter_rows, self.schemas))
         rows = zip(*it_rows) if len(it_rows) > 1 else it_rows[0]
         if self._shuffle_buffer_size > 0:
             rows = _iter_shuffled(rows, self._shuffle_buffer_size)
         return rows
 
-    def _iter_rows(self, schema: TensorSchema) -> Iterator[TensorOrSequence]:
+    def _iter_rows(self, schema: TensorSchema[Tensor]) -> Iterator[TensorOrSequence]:
         max_weight = schema.max_partition_weight
         key_subranges = self.key_range.partition_by_weight(max_weight)
-        batches: Iterable[TensorOrSequence] = schema.iter_tensors(key_subranges)
+        batches = schema.iter_tensors(key_subranges)
         if schema.num_fields == 1:
             return (tensor for batch in batches for tensor in batch)
         else:
@@ -102,19 +104,10 @@ class _PyTorchTileDBDataset(IterableDataset[OneOrMoreTensorsOrSequences]):
 def _worker_init(worker_id: int) -> None:
     worker_info = get_worker_info()
     dataset = worker_info.dataset
-    if any(isinstance(schema, SparseTensorSchema) for schema in dataset.schemas):
+    if any(schema.kind is not TensorKind.DENSE for schema in dataset.schemas):
         raise NotImplementedError("https://github.com/pytorch/pytorch/issues/20248")
     key_ranges = list(dataset.key_range.partition_by_count(worker_info.num_workers))
     dataset.key_range = key_ranges[worker_id]
-
-
-def _get_tensor_schema(array_params: ArrayParams) -> TensorSchema:
-    if not array_params.array.schema.sparse:
-        return DenseTensorSchema.from_array_params(array_params)
-    elif array_params.array.ndim == 2:
-        return SparseTensorSchema.from_array_params(array_params, methodcaller("tocsr"))
-    else:
-        return SparseTensorSchema.from_array_params(array_params)
 
 
 _SingleCollator = Callable[[TensorSequence], torch.Tensor]
@@ -161,16 +154,17 @@ def _sparse_csr_collate(arrays: Sequence[scipy.sparse.csr_matrix]) -> torch.Tens
     )
 
 
-def _get_tensor_collator(
-    schema: TensorSchema,
-) -> Union[_SingleCollator, _CompositeCollator]:
-    if not isinstance(schema, SparseTensorSchema):
-        collator = _ndarray_collate
-    elif len(schema.shape) != 2:
-        collator = _sparse_coo_collate
-    else:
-        collator = _sparse_csr_collate
+_collators = {
+    TensorKind.DENSE: _ndarray_collate,
+    TensorKind.SPARSE_COO: _sparse_coo_collate,
+    TensorKind.SPARSE_CSR: _sparse_csr_collate,
+}
 
+
+def _get_tensor_collator(
+    schema: TensorSchema[Tensor],
+) -> Union[_SingleCollator, _CompositeCollator]:
+    collator = _collators[schema.kind]
     num_fields = schema.num_fields
     if num_fields == 1:
         return collator
@@ -197,5 +191,4 @@ def _iter_shuffled(iterable: Iterable[_T], buffer_size: int) -> Iterator[_T]:
         yield buffer[idx]
         buffer[idx] = x
     random.shuffle(buffer)
-    while buffer:
-        yield buffer.pop()
+    yield from buffer

--- a/tiledb/ml/readers/tensorflow.py
+++ b/tiledb/ml/readers/tensorflow.py
@@ -65,9 +65,11 @@ TensorSpec = Union[tf.TensorSpec, tf.SparseTensorSpec]
 
 
 def _get_tensor_specs(schema: TensorSchema) -> Union[TensorSpec, Sequence[TensorSpec]]:
-    cls = tf.SparseTensorSpec if schema.sparse else tf.TensorSpec
+    spec_cls = (
+        tf.SparseTensorSpec if isinstance(schema, SparseTensorSchema) else tf.TensorSpec
+    )
     shape = (None, *schema.shape[1:])
-    specs = tuple(cls(shape=shape, dtype=dtype) for dtype in schema.field_dtypes)
+    specs = tuple(spec_cls(shape=shape, dtype=dtype) for dtype in schema.field_dtypes)
     return specs if len(specs) > 1 else specs[0]
 
 


### PR DESCRIPTION
This PR:
- Introduces a `TensorKind` enumeration with 3 values: `DENSE`, `SPARSE_COO`, `SPARSE_CSR`.
- Adds a `tensor_kind` optional parameter to `ArrayParams` that allows the user to specify the kind of generated tensors. This parameter generalizes (and replaces) the current `csr` parameter of `PyTorchTileDBDataLoader`.

These changes:
1. Lay the groundwork for adding more tensor kinds, namely ragged tensors.
2. Decouple the TileDB array flavor (dense or sparse) from the generated tensor kind (dense, sparse COO, sparse CSR, ...). For example, this paves the way for generating dense tensors from sparse TileDB arrays or vice versa (currently not implemented).
3. Allow defining the mapping from TileDB to tensors per array. For example currently is not possible to generate sparse CSR tensors from the `x` array and sparse COO tensors from the `y` array.

Internal changes:
- Consolidate all the `ArrayParams -> TensorSchema` conversion logic to `ArrayParams.to_tensor_schema()`. Callers just need to pass an optional `tensor_kind -> transform_func` mapping with the transform function per tensor kind.
- Make `TensorSchema` a generic type with a `Tensor` type parameter.
- Move the reader transform/map logic out of the base `TensorSchema` to a separate `MappedTensorSchema` proxy class.
- Make `SparseTensorSchema.key_range` (effectively) a cached property that caches the key_range the first time it is computed.
- Drop the `TensorSchema.sparse` property and and replace the `fields` property with `num_fields`
- Drop the `_csr_to_coo_collate` Pytorch collator
