### PR TITLE
Read from sparse TileDB arrays to ragged tensors

### DIFF
--- a/tiledb/ml/readers/_tensor_schema.py
+++ b/tiledb/ml/readers/_tensor_schema.py
@@ -12,6 +12,7 @@ from typing import (
     Dict,
     Generic,
     Iterable,
+    Optional,
     Sequence,
     Tuple,
     Type,
@@ -36,6 +37,7 @@ class TensorKind(enum.Enum):
     DENSE = enum.auto()
     SPARSE_COO = enum.auto()
     SPARSE_CSR = enum.auto()
+    RAGGED = enum.auto()
 
 
 Tensor = TypeVar("Tensor")
@@ -66,7 +68,7 @@ class TensorSchema(ABC, Generic[Tensor]):
         return tuple(map(self._array.schema.attr_or_dim_dtype, self._fields))
 
     @property
-    def shape(self) -> Sequence[int]:
+    def shape(self) -> Sequence[Optional[int]]:
         """Shape of the array, with the key dimension moved first.
 
         **Note**: For sparse arrays, the returned shape reflects the non-empty domain of
@@ -121,7 +123,7 @@ class TensorSchema(ABC, Generic[Tensor]):
         self, key_ranges: Iterable[InclusiveRange[Any, int]]
     ) -> Union[Iterable[Tensor], Iterable[Sequence[Tensor]]]:
         """
-        Generate batches of dense or sparse tensors.
+        Generate batches of tensors.
 
         Each yielded batch is either:
         - a sequence of N tensors if N > 1, where `N == self.num_fields`, or
@@ -314,7 +316,7 @@ class SparseTensorSchema(BaseSparseTensorSchema[SparseData]):
     def iter_tensors(
         self, key_ranges: Iterable[InclusiveRange[Any, int]]
     ) -> Union[Iterable[SparseData], Iterable[Sequence[SparseData]]]:
-        shape = list(self.shape)
+        shape = list(cast(Sequence[int], self.shape))
         query = self.query
         get_data = itemgetter(*self._fields)
         single_field = len(self._fields) == 1
@@ -344,8 +346,65 @@ class SparseTensorSchema(BaseSparseTensorSchema[SparseData]):
                 yield tuple(SparseData(coords, d, shape) for d in data)
 
 
+RaggedArray = Sequence[np.ndarray]
+
+
+class RaggedTensorSchema(BaseSparseTensorSchema[RaggedArray]):
+    """TensorSchema for reading sparse TileDB arrays as ragged Numpy arrays.
+
+    Each ragged array is represented as a sequence of 1D Numpy arrays of the same dtype
+    but (in general) different size. Each item of the ragged array contains the values of
+    a given field for a given key (i.e. value along the key dimension). The items of the
+    ragged array are ordered by the key dimension but the values within each item are not
+    (meaningfully) ordered.
+
+    Example:
+    - (key, field1, field2) cells:
+        {('a', 3, 2.8), ('b', 1, 0.2), ('a', 7, 3.2), ('c', 5, 6.1), ('c', 2, 0.5), ('a', 2, 1.9)}
+
+    - Ragged arrays:
+        - key: [np.array(['a', 'a', 'a']), np.array(['b']), np.array(['c', 'c'])]
+        - field1: [np.array([3, 7, 2]), np.array([1]), np.array([5, 2])]
+        - field2: [np.array([2.8, 3.2, 1.9]), np.array([0.2]), np.array([6.1, 0.5])]
+    """
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        if self.key_dim not in self._query_kwargs["dims"]:
+            self._query_kwargs["dims"] += (self.key_dim,)
+
+    @property
+    def shape(self) -> Sequence[Optional[int]]:
+        return len(self.key_range), None
+
+    def iter_tensors(
+        self, key_ranges: Iterable[InclusiveRange[int, int]]
+    ) -> Union[Iterable[RaggedArray], Iterable[Sequence[RaggedArray]]]:
+        query = self.query
+        get_data = itemgetter(*self._fields)
+        key_dim = self.key_dim
+        for key_range in key_ranges:
+            field_arrays = query[key_range.min : key_range.max]
+            # Sort the key dimension values and find the indices where the value changes
+            sort_idx = np.argsort(field_arrays[key_dim])
+            split_idx = argdiff(field_arrays[key_dim][sort_idx])
+            # apply the same sorting and splitting to all the field arrays
+            for name, values in field_arrays.items():
+                field_arrays[name] = np.split(values[sort_idx], split_idx)
+            yield get_data(field_arrays)
+
+
+def argdiff(a: np.ndarray) -> np.ndarray:
+    """Return the indices `i` of the array `a` so that `a[i] != a[i-1]`."""
+    idx = np.nonzero(a[:-1] != a[1:])[0]
+    # the minimum diff index (if a[0] != a[1]) is 1, not 0
+    idx += 1
+    return idx
+
+
 TensorSchemaFactories: Dict[TensorKind, Type[TensorSchema[Any]]] = {
     TensorKind.DENSE: DenseTensorSchema,
+    TensorKind.RAGGED: RaggedTensorSchema,
     TensorKind.SPARSE_COO: SparseTensorSchema,
     TensorKind.SPARSE_CSR: SparseTensorSchema,
 }

--- a/tiledb/ml/readers/_tensor_schema.py
+++ b/tiledb/ml/readers/_tensor_schema.py
@@ -386,7 +386,7 @@ class RaggedTensorSchema(BaseSparseTensorSchema[RaggedArray]):
         for key_range in key_ranges:
             field_arrays = query[key_range.min : key_range.max]
             # Sort the key dimension values and find the indices where the value changes
-            sort_idx = np.argsort(field_arrays[key_dim])
+            sort_idx = np.argsort(field_arrays[key_dim], kind="stable")
             split_idx = argdiff(field_arrays[key_dim][sort_idx])
             # apply the same sorting and splitting to all the field arrays
             for name, values in field_arrays.items():

--- a/tiledb/ml/readers/tensorflow.py
+++ b/tiledb/ml/readers/tensorflow.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Mapping, Sequence, Union
 import numpy as np
 import tensorflow as tf
 
-from ._tensor_schema import SparseData, TensorKind, TensorSchema
+from ._tensor_schema import RaggedArray, SparseData, TensorKind, TensorSchema
 from .types import ArrayParams
 
 Tensor = Union[np.ndarray, tf.SparseTensor]
@@ -58,6 +58,7 @@ def TensorflowTileDBDataset(
 _tensor_specs = {
     TensorKind.DENSE: tf.TensorSpec,
     TensorKind.SPARSE_COO: tf.SparseTensorSpec,
+    TensorKind.RAGGED: tf.RaggedTensorSpec,
 }
 
 
@@ -80,8 +81,13 @@ def _to_sparse_tensor(sd: SparseData) -> tf.SparseTensor:
     return tf.SparseTensor(coords.T, sa.data, sa.shape)
 
 
+def _to_ragged_tensor(ra: RaggedArray) -> tf.RaggedTensor:
+    return tf.ragged.constant(ra, dtype=ra[0].dtype)
+
+
 _transforms: Mapping[TensorKind, Union[Callable[[Any], Any], bool]] = {
     TensorKind.DENSE: True,
     TensorKind.SPARSE_COO: _to_sparse_tensor,
     TensorKind.SPARSE_CSR: False,
+    TensorKind.RAGGED: _to_ragged_tensor,
 }


### PR DESCRIPTION
This PR adds support for loading data from any sparse TileDB array as [ragged (aka jagged) tensors](https://en.wikipedia.org/wiki/Jagged_array). This allows reading sparse TileDB arrays with non-integer dimensions, which was not possible until now, but even arrays with only integer dimensions can be mapped to ragged (instead of sparse) tensors.

### Description

- Each ragged array is conceptually a sequence of 1D Numpy arrays of the same dtype but (in general) different size. 
- Each item (i.e. 1D array) of the ragged array contains the values of a given field (attribute or dimension) for a given key (i.e. value along the key dimension). 
- The items of the ragged array are ordered by the key dimension but the values within each item are not (meaningfully) ordered.

#### Example

- Input: a sparse TileDB array with a key dimension `key_dim` and two fields (dimensions and/or attributes) of interest, `field1` and `field2`, with dtypes string, int, and float respectively.
- The non-empty `(key_dim, field1, field2)` triplets are:
```
('a', 3, 2.8)
('b', 1, 0.2)
('a', 7, 1.2)
('c', 5, 6.1)
('c', 2, 7.5)
('a', 2, 1.9)
```
- The ragged array representation of this data is:
   - `key_dim`: `[['a', 'a', 'a'], ['b'], ['c', 'c']]`
   - `field1`: `[[3, 7, 2]), [1], [5, 2]]`
   - `field2`: `[[2.8, 1.2, 1.9]), [0.2], [6.1, 7.5]]`

### Implementation
- A new `RAGGED` member is added to the `TensorKind` enumeration.
  - `TensorKind.RAGGED` is the default tensor kind for sparse arrays with at least one non-integer non-key dimension. However the user may pass explicitly `tensor_kind=TensorKind.RAGGED` to `ArrayParams` for any sparse TileDB array.
- A new `RaggedTensorSchema` subclass of `TensorSchema` is added for reading from a sparse TileDB array to ragged Numpy arrays.
  -  `RaggedTensorSchema` shares some functionality with `SparseTensorSchema`; the common bits are extracted to `BaseSparseTensorSchema` that both of them inherit.
- `TensorflowTileDBDataset` is updated to map each ragged Numpy array to a [`tensorflow.RaggedTensor`](https://www.tensorflow.org/guide/ragged_tensor).
- `PyTorchTileDBDataLoader` is updated to map each ragged Numpy array to a [torch.nested](https://pytorch.org/docs/stable/nested.html) tensor (available in torch>=1.12).

