### PR TITLE
Avoid intermediate `sparse.COO` instances if possible

### DIFF
--- a/tiledb/ml/readers/_tensor_schema.py
+++ b/tiledb/ml/readers/_tensor_schema.py
@@ -241,7 +241,7 @@ class SparseData:
     data: np.ndarray
     shape: Sequence[int]
 
-    def to_array(self) -> Union[scipy.sparse.csr_matrix, sparse.COO]:
+    def to_sparse_array(self) -> Union[scipy.sparse.csr_matrix, sparse.COO]:
         if len(self.shape) == 2:
             return scipy.sparse.csr_matrix((self.data, self.coords), self.shape)
         else:

--- a/tiledb/ml/readers/_tensor_schema.py
+++ b/tiledb/ml/readers/_tensor_schema.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections import Counter
 from dataclasses import dataclass
 from math import ceil
-from operator import itemgetter, methodcaller
+from operator import itemgetter
 from typing import (
     Any,
     Callable,
@@ -14,6 +14,7 @@ from typing import (
     Iterable,
     Sequence,
     Tuple,
+    Type,
     TypeVar,
     Union,
     cast,
@@ -234,9 +235,22 @@ class DenseTensorSchema(TensorSchema[np.ndarray]):
         return max(1, int(rows_per_slice * num_slices))
 
 
-class SparseTensorSchema(TensorSchema[sparse.COO]):
+@dataclass(frozen=True)
+class SparseData:
+    coords: np.ndarray
+    data: np.ndarray
+    shape: Sequence[int]
+
+    def to_array(self) -> Union[scipy.sparse.csr_matrix, sparse.COO]:
+        if len(self.shape) == 2:
+            return scipy.sparse.csr_matrix((self.data, self.coords), self.shape)
+        else:
+            return sparse.COO(self.coords, self.data, self.shape)
+
+
+class SparseTensorSchema(TensorSchema[SparseData]):
     """
-    TensorSchema for reading sparse TileDB arrays as sparse.COO instances.
+    TensorSchema for reading sparse TileDB arrays as SparseData instances.
     """
 
     def __init__(self, **kwargs: Any):
@@ -263,7 +277,7 @@ class SparseTensorSchema(TensorSchema[sparse.COO]):
 
     def iter_tensors(
         self, key_ranges: Iterable[InclusiveRange[Any, int]]
-    ) -> Union[Iterable[sparse.COO], Iterable[Sequence[sparse.COO]]]:
+    ) -> Union[Iterable[SparseData], Iterable[Sequence[SparseData]]]:
         shape = list(self.shape)
         query = self.query
         get_data = itemgetter(*self._fields)
@@ -285,12 +299,13 @@ class SparseTensorSchema(TensorSchema[sparse.COO]):
                 field_arrays.pop(dim) - dim_start
                 for dim, dim_start in zip(non_key_dims, non_key_dim_starts)
             )
+            coords = np.array(coords)
 
-            # yield either a single tensor or a sequence of tensors, one for each field
+            # yield either a single SparseData or one SparseData per field
             if single_field:
-                yield sparse.COO(coords, data, shape)
+                yield SparseData(coords, data, shape)
             else:
-                yield tuple(sparse.COO(coords, d, shape) for d in data)
+                yield tuple(SparseData(coords, d, shape) for d in data)
 
     @property
     def max_partition_weight(self) -> int:
@@ -322,18 +337,10 @@ class SparseTensorSchema(TensorSchema[sparse.COO]):
         return max(1, memory_budget // ceil(max(bytes_per_cell)))
 
 
-def SparseCSRTensorSchema(**kwargs: Any) -> TensorSchema[scipy.sparse.csr_matrix]:
-    """
-    Return a TensorSchema for reading sparse 2D TileDB arrays as scipy.sparse.csr_matrix
-    instances.
-    """
-    return MappedTensorSchema(SparseTensorSchema(**kwargs), methodcaller("tocsr"))
-
-
-TensorSchemaFactories = {
+TensorSchemaFactories: Dict[TensorKind, Type[TensorSchema[Any]]] = {
     TensorKind.DENSE: DenseTensorSchema,
     TensorKind.SPARSE_COO: SparseTensorSchema,
-    TensorKind.SPARSE_CSR: SparseCSRTensorSchema,
+    TensorKind.SPARSE_CSR: SparseTensorSchema,
 }
 
 

--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -178,7 +178,7 @@ def _get_tensor_collator(
             collator = _csr_to_coo_collate
     elif schema.kind is TensorKind.SPARSE_CSR:
         if len(schema.shape) != 2:
-            raise ValueError(f"SPARSE_CSR is supported only for 2D tensors")
+            raise ValueError("SPARSE_CSR is supported only for 2D tensors")
         collator = _csr_collate
     else:
         assert False, schema.kind
@@ -192,8 +192,8 @@ def _get_tensor_collator(
 
 _transforms: Mapping[TensorKind, Union[Callable[[Any], Any], bool]] = {
     TensorKind.DENSE: True,
-    TensorKind.SPARSE_COO: methodcaller("to_array"),
-    TensorKind.SPARSE_CSR: methodcaller("to_array"),
+    TensorKind.SPARSE_COO: methodcaller("to_sparse_array"),
+    TensorKind.SPARSE_CSR: methodcaller("to_sparse_array"),
 }
 
 

--- a/tiledb/ml/readers/tensorflow.py
+++ b/tiledb/ml/readers/tensorflow.py
@@ -71,7 +71,7 @@ def _get_tensor_specs(
 
 
 def _to_sparse_tensor(sd: SparseData) -> tf.SparseTensor:
-    sa = sd.to_array()
+    sa = sd.to_sparse_array()
     coords = getattr(sa, "coords", None)
     if coords is None:
         # sa is a scipy.sparse.csr_matrix


### PR DESCRIPTION
#136  reintroduced `scipy.sparse` for 2D sparse arrays as it is more efficient than `sparse.COO` for iteration over rows. However `SparseTensorSchema` (used to be called `TileDBSparseGenerator`) still created `sparse.COO` instances and converted them to `scipy.sparse.csr_matrix` if possible (and only for `PyTorchTileDBDataLoader`).

This PR goes a step further by:
- Introducing a lightweight `SparseData` dataclass.
- Yielding `SparseData` instances from `SparseTensorSchema` instead of `sparse.COO`.
- Converting `SparseData` to `scipy.sparse.csr_matrix` for 2D sparse arrays and `sparse.COO` otherwise, both for Pytorch and Tensorflow.
- Bringing back the `_csr_to_coo_collate` Pytorch collator that was removed in #167.
