### PR TITLE
Fix PyTorchTileDBDataLoader to be iterable more than once

### DIFF
--- a/tests/readers/test_pytorch.py
+++ b/tests/readers/test_pytorch.py
@@ -36,6 +36,11 @@ class TestPyTorchTileDBDataLoader:
                     validate_tensor_generator(
                         dataloader, x_spec, y_spec, batch_size, supports_csr=True
                     )
+                    # ensure the dataloader can be iterated again
+                    n1 = sum(1 for _ in dataloader)
+                    assert n1 != 0
+                    n2 = sum(1 for _ in dataloader)
+                    assert n1 == n2
 
     @parametrize_for_dataset(
         non_key_dim_dtype=non_key_dim_dtype,


### PR DESCRIPTION
Fix for https://github.com/TileDB-Inc/TileDB-ML/pull/173 to allow a `PyTorchTileDBDataLoader` instance to be iterated more than once; currently it acts as an iterator that is exhausted after the first iteration.