### PR TITLE
Bump pytorch version to 1.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,13 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         ml-deps:
-          - "torch==1.10.2+cpu tensorflow-cpu==2.6.3"
-          - "torch==1.11.0+cpu tensorflow-cpu==2.7.1"
-          - "torch==1.12.0+cpu tensorflow-cpu==2.8.1"
+          - "torch==1.12.0+cpu torchvision==0.13.0+cpu torchdata==0.4.0 tensorflow-cpu==2.7.1"
+          - "torch==1.12.1+cpu torchvision==0.13.1+cpu torchdata==0.4.1 tensorflow-cpu==2.8.1"
 
     env:
       run_coverage: ${{ github.ref == 'refs/heads/master' }}
@@ -35,7 +34,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -f https://download.pytorch.org/whl/torch_stable.html protobuf==3.* ${{ matrix.ml-deps }}
-        pip install pytest-mock pytest-cov torchdata scikit-learn==1.0.2
+        pip install pytest-mock pytest-cov scikit-learn==1.0.2
         pip install -e .[cloud]
 
     - name: Run mypy
@@ -47,7 +46,7 @@ jobs:
 
     - name: Run notebook examples
       run: |
-        pip install pytest-xdist nbmake matplotlib torchvision idx2numpy
+        pip install pytest-xdist nbmake matplotlib idx2numpy
         pytest --disable-warnings --nbmake examples/{models,readers}
         # Run tiledb-cloud in parallel
         if [[ "${{ secrets.TILEDB_API_TOKEN }}" != "" ]]; then

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 tensorflow = ["tensorflow>=2.6"]
-pytorch = ["torch>=1.10", "torchdata"]
+pytorch = ["torch>=1.12", "torchdata"]
 sklearn = ["scikit-learn>=1.0"]
 cloud = ["tiledb-cloud"]
 full = sorted({"torchvision", *tensorflow, *pytorch, *sklearn, *cloud})

--- a/tests/readers/test_pytorch.py
+++ b/tests/readers/test_pytorch.py
@@ -36,6 +36,11 @@ class TestPyTorchTileDBDataLoader:
                     validate_tensor_generator(
                         dataloader, x_spec, y_spec, batch_size, supports_csr=True
                     )
+                    # ensure the dataloader can be iterated again
+                    n1 = sum(1 for _ in dataloader)
+                    assert n1 != 0
+                    n2 = sum(1 for _ in dataloader)
+                    assert n1 == n2
 
     @parametrize_for_dataset(
         non_key_dim_dtype=non_key_dim_dtype,


### PR DESCRIPTION
Bump pytorch to 1.12 to support `torchdata` introduced in https://github.com/TileDB-Inc/TileDB-ML/pull/173:
- torchdata is available for torch 1.11 or later. This was not caught by the CI when testing against torch 1.10 because torchdata was installed after torch and triggered a reinstallation to the latest version (1.12).
- the [ShardingFilter](https://pytorch.org/data/main/generated/torchdata.datapipes.iter.ShardingFilter.html) of torchdata doesn't seem to work at version 0.3 (required for torch 1.11); all data are processed by all workers. In torchdata 0.4 / torch 1.12 sharding works correctly.

Also torch 1.12 has better support than 1.11 for sparse CSR tensors. The `pytorch_data_api_tiledb_sparse.ipynb` example notebook fails at the last cell on torch 1.11 if `TensorKind.SPARSE_CSR` (default for 2D sparse arrays) is passed in `ArrayParams`.