### PR TITLE
Add support for slicing on non-key indices

### DIFF
--- a/tests/readers/test_tensor_schema.py
+++ b/tests/readers/test_tensor_schema.py
@@ -86,27 +86,6 @@ def parametrize_fields(*fields):
         list(it.chain.from_iterable(it.combinations(fields, i) for i in range(4))),
     )
 
-
-@pytest.mark.parametrize(
-    "key_dim_index,memory_budget",
-    [(0, 16_000), (0, 32_000), (0, 64_000), (1, 500_000), (1, 600_000), (1, 700_000)],
-)
-@parametrize_fields("d0", "d1", "d2", "af8", "af4", "au1")
-def test_max_partition_weight_dense(dense_uri, fields, key_dim_index, memory_budget):
-    config = {"py.max_incomplete_retries": 0, "sm.memory_budget": memory_budget}
-    with tiledb.open(dense_uri, config=config) as a:
-        schema = ArrayParams(a, key_dim_index, fields).to_tensor_schema()
-        max_weight = schema.max_partition_weight
-        for key_range in schema.key_range.partition_by_weight(max_weight):
-            # query succeeds without incomplete retries
-            schema.query[key_range.min : key_range.max]
-
-            if key_range.max < schema.key_range.max:
-                # querying a larger slice should fail
-                with pytest.raises(tiledb.TileDBError) as ex:
-                    schema.query[key_range.min : key_range.max + 1]
-                assert "py.max_incomplete_retries" in str(ex.value)
-
 @pytest.mark.parametrize(
     "key_dim_index,memory_budget",
     [(0, 16_000), (0, 32_000), (0, 64_000), (1, 500_000), (1, 600_000), (1, 700_000)],
@@ -124,7 +103,7 @@ def test_max_partition_weight_dense(dense_uri, fields, key_dim_index, memory_bud
     ]
 )
 @parametrize_fields("d0", "d1", "d2", "af8", "af4", "au1")
-def test_max_partition_weight_dense_secondary_slice(dense_uri, fields, key_dim_index, memory_budget, secondary_slices):
+def test_max_partition_weight_dense(dense_uri, fields, key_dim_index, memory_budget, secondary_slices):
     config = {"py.max_incomplete_retries": 0, "sm.memory_budget": memory_budget}
     with tiledb.open(dense_uri, config=config) as a:
         schema = ArrayParams(a, key_dim_index, fields, secondary_slices=secondary_slices).to_tensor_schema()

--- a/tests/readers/test_tensor_schema.py
+++ b/tests/readers/test_tensor_schema.py
@@ -110,7 +110,6 @@ def test_max_partition_weight_dense(dense_uri, fields, key_dim_index, memory_bud
         max_weight = schema.max_partition_weight
         for key_range in schema.key_range.partition_by_weight(max_weight):
             # query succeeds without incomplete retries
-            print(key_range.min, key_range.max)
             schema.query[key_range.min : key_range.max]
                     
             if key_range.max < schema.key_range.max:

--- a/tests/readers/test_tensor_schema.py
+++ b/tests/readers/test_tensor_schema.py
@@ -111,7 +111,7 @@ def test_max_partition_weight_dense(dense_uri, fields, key_dim_index, memory_bud
         for key_range in schema.key_range.partition_by_weight(max_weight):
             # query succeeds without incomplete retries
             schema.query[key_range.min : key_range.max]
-                    
+
             if key_range.max < schema.key_range.max:
                 # querying a larger slice should fail
                 with pytest.raises(tiledb.TileDBError) as ex:

--- a/tiledb/ml/readers/_tensor_schema.py
+++ b/tiledb/ml/readers/_tensor_schema.py
@@ -438,13 +438,11 @@ class KeyDimQuery:
             if secondary_index == self._key_dim_index:
                 secondary_index = 0
             self._slices[secondary_index] = secondary_slice
-        print("sec slics2", secondary_slices)
 
 
     def __getitem__(self, key_dim_slice: slice) -> Dict[str, np.ndarray]:
         """Query the TileDB array by `dim_key=key_dim_slice`."""
         slices = (*self._slices[:self._key_dim_index], key_dim_slice, *self._slices[self._key_dim_index + 1:])
-        print("slices", slices)
         return cast(
             Dict[str, np.ndarray],
             self._multi_index[slices],

--- a/tiledb/ml/readers/types.py
+++ b/tiledb/ml/readers/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Callable, Mapping, Optional, Sequence, Union
+from typing import Any, Callable, Mapping, Optional, Sequence, Union, Dict
 
 import numpy as np
 
@@ -15,9 +15,24 @@ from ._tensor_schema import (
 
 @dataclass(frozen=True)
 class ArrayParams:
+    """
+    Class for defining the parameters for accessing an array. 
+    Constructor arguments:
+    :param array: TileDB Array to be accessed
+    :param key_dim: name or index of key dimension of array
+    :param fields: fields (dimensions and attributes) to be retrieved from array
+    :param secondary_slices: additional slices to slice on non-key indices (e.g. for cropping 
+    images). Should be a dictionary mapping from the desired dimension name to be sliced to 
+    a slice object, single index, or list of indices.
+    :param tensor_kind: kind of tensor desired
+    :param _tensor_schema_kwargs: other kwargs to pass to the tensor schema instantiated in 
+    `to_tensor_schema`.
+    """
+
     array: tiledb.Array
     key_dim: Union[int, str] = 0
     fields: Sequence[str] = ()
+    secondary_slices: Dict[str, Union[int, slice, Sequence[int]]] = field(default_factory=dict)
     tensor_kind: Optional[TensorKind] = None
     _tensor_schema_kwargs: Mapping[str, Any] = field(init=False, repr=False)
 
@@ -45,10 +60,17 @@ class ArrayParams:
             if isinstance(self.key_dim, int)
             else all_dims.index(self.key_dim)
         )
+
         if key_dim_index > 0:
             # Swap key dimension to first position
             all_dims[0], all_dims[key_dim_index] = all_dims[key_dim_index], all_dims[0]
             ned[0], ned[key_dim_index] = ned[key_dim_index], ned[0]
+        
+        secondary_slices_indices = {}
+        for dim, secondary_slice in self.secondary_slices.items():
+            dim_index = all_dims.index(dim)
+            if dim_index > 0: # don't secondarily slice the key_dim_index
+                secondary_slices_indices[dim_index] = secondary_slice
 
         tensor_schema_kwargs = dict(
             _array=self.array,
@@ -56,6 +78,7 @@ class ArrayParams:
             _fields=tuple(final_fields),
             _all_dims=tuple(all_dims),
             _ned=tuple(ned),
+            _secondary_slices=secondary_slices_indices,
             _query_kwargs={"attrs": tuple(attrs), "dims": tuple(dims)},
         )
         object.__setattr__(self, "_tensor_schema_kwargs", tensor_schema_kwargs)
@@ -90,6 +113,11 @@ class ArrayParams:
         else:
             tensor_kind = TensorKind.SPARSE_CSR
 
+        if tensor_kind is not TensorKind.DENSE and len(self.secondary_slices) > 0:
+            raise NotImplementedError(
+                f"Slicing on secondary indices is only implemented for dense arrays"
+            )
+        
         transform = transforms.get(tensor_kind, True)
         if not transform:
             raise NotImplementedError(


### PR DESCRIPTION
Hello! My name is Kalyan and I work at [Enable Medicine](https://enablemedicine.com/). We are experimenting using TileDB for our ML infrastructure. One feature that we need is the ability to do (constant) slices on the non-key indices of training samples. An example workload is storing a dataset with very large images, with different users training on crops of different sizes. This minimizes unnecessary I/O by only fetching necessary tiles rather than cropping after downloading the full image.

This PR allows the user to pass a dictionary as an argument `secondary_slices` to `ArrayParams`. This dictionary maps from dimension names to a slice object, an array of indices, or a single index. Example:

```
# Array of 256x256 training images with dimensions "batch", "length", "width", "channel"
with tiledb.open(uri) as A:
    # train on top left quarter of each image
    params = ArrayParams(A, secondary_slices={"length": slice(0, 63), "width": slice(0:63)})
    ...
```


I'm fairly new to the codebase so forgive me if I made some mistakes. Let me know if there are any changes I need to make!