### PR TITLE
Default to TensorKind.SPARSE_COO for sparse tensors 

### DIFF
--- a/tests/readers/test_tensor_schema.py
+++ b/tests/readers/test_tensor_schema.py
@@ -95,7 +95,7 @@ def parametrize_fields(*fields):
 def test_max_partition_weight_dense(dense_uri, fields, key_dim_index, memory_budget):
     config = {"py.max_incomplete_retries": 0, "sm.memory_budget": memory_budget}
     with tiledb.open(dense_uri, config=config) as a:
-        schema = ArrayParams(a, key_dim_index, fields).to_tensor_schema()
+        schema = ArrayParams(a, key_dim_index, fields).tensor_schema
         max_weight = schema.max_partition_weight
         for key_range in schema.key_range.partition_by_weight(max_weight):
             # query succeeds without incomplete retries
@@ -118,7 +118,7 @@ def test_max_partition_weight_sparse(sparse_uri, fields, key_dim_index, memory_b
     }
     with tiledb.open(sparse_uri, config=config) as a:
         key_dim = a.dim(key_dim_index)
-        schema = ArrayParams(a, key_dim_index, fields).to_tensor_schema()
+        schema = ArrayParams(a, key_dim_index, fields).tensor_schema
         max_weight = schema.max_partition_weight
         for key_range in schema.key_range.partition_by_weight(max_weight):
             # query succeeds without incomplete retries

--- a/tiledb/ml/readers/types.py
+++ b/tiledb/ml/readers/types.py
@@ -85,10 +85,8 @@ class ArrayParams:
             for dim in self._tensor_schema_kwargs["_all_dims"][1:]
         ):
             tensor_kind = TensorKind.RAGGED
-        elif self.array.ndim != 2 or not transforms.get(TensorKind.SPARSE_CSR, True):
-            tensor_kind = TensorKind.SPARSE_COO
         else:
-            tensor_kind = TensorKind.SPARSE_CSR
+            tensor_kind = TensorKind.SPARSE_COO
 
         transform = transforms.get(tensor_kind, True)
         if not transform:


### PR DESCRIPTION
Currently we default to `TensorKind.SPARSE_CSR` for 2D sparse arrays on Pytorch, However the CSR sparse tensor format:
- is not implemented for Tensorflow
- is in beta state for Pytorch even on the latest version (1.12) and triggers `UserWarning: Sparse CSR tensor support is in beta state. If you miss a functionality in the sparse tensor support, please submit a feature request to https://github.com/pytorch/pytorch/issues`

This small PR changes the default sparse tensor kind to be always `TensorKind.SPARSE_COO` for both Pytorch and Tensorflow, regardless of the array shape. The user can still select CSR tensors by passing explicitly `tensor_kind=TensorKind.SPARSE_CSR` to `ArrayParams`.
