### PR TITLE
Remove SparseData

### DIFF
--- a/tiledb/ml/readers/_pytorch_collators.py
+++ b/tiledb/ml/readers/_pytorch_collators.py
@@ -47,7 +47,7 @@ class Collator(ABC, Generic[T]):
             assert schema.kind in (TensorKind.SPARSE_COO, TensorKind.SPARSE_CSR)
             to_csr = schema.kind is TensorKind.SPARSE_CSR
             # The sparse arrays to be converted/collated are scipy.sparse.csr_matrix if
-            # (and only if) the schema ndim == 2; see SparseData.to_sparse_array()
+            # (and only if) the schema ndim == 2
             if len(schema.shape) == 2:
                 collator = ScipySparseCSRCollator(to_csr)
             else:

--- a/tiledb/ml/readers/tensorflow.py
+++ b/tiledb/ml/readers/tensorflow.py
@@ -8,7 +8,7 @@ import tensorflow as tf
 from ._tensor_schema import (
     MappedTensorSchema,
     RaggedArray,
-    SparseData,
+    SparseArray,
     TensorKind,
     TensorSchema,
 )
@@ -84,8 +84,7 @@ def _get_tensor_specs(
     return specs if len(specs) > 1 else specs[0]
 
 
-def _to_sparse_tensor(sd: SparseData) -> tf.SparseTensor:
-    sa = sd.to_sparse_array()
+def _to_sparse_tensor(sa: SparseArray) -> tf.SparseTensor:
     coords = getattr(sa, "coords", None)
     if coords is None:
         # sa is a scipy.sparse.csr_matrix


### PR DESCRIPTION
Small PR that removes the intermediate `SparseData` dataclass introduced in #172 and lets `SparseTensorSchema` generate directly sparse arrays (`scipy.sparse.csr_matrix` instances for 2D sparse arrays and `sparse.COO` instances otherwise).