### PR TITLE
Support reading dense tensors from sparse arrays

### DIFF
--- a/tests/readers/test_tensorflow.py
+++ b/tests/readers/test_tensorflow.py
@@ -59,6 +59,7 @@ class TestTensorflowTileDBDataset:
             key_dim_dtype=spec.key_dim_dtype,
             non_key_dim_dtype=spec.non_key_dim_dtype,
             num_fields=spec.num_fields,
+            tensor_kind=spec.tensor_kind,
         )
         with ingest_in_tiledb(tmpdir, spec) as (x_params, x_data):
             with ingest_in_tiledb(tmpdir, y_spec) as (y_params, y_data):
@@ -87,11 +88,14 @@ class TestTensorflowTileDBDataset:
 
     @pytest.mark.parametrize(
         "spec",
-        ArraySpec.combinations(sparse=(True,), non_key_dim_dtype=(np.dtype(np.int32),)),
+        ArraySpec.combinations(
+            sparse=[True],
+            non_key_dim_dtype=[np.dtype(np.int32)],
+            tensor_kind=[TensorKind.SPARSE_CSR],
+        ),
     )
     def test_csr(self, tmpdir, spec):
-        tensor_kind = TensorKind.SPARSE_CSR
-        with ingest_in_tiledb(tmpdir, spec, tensor_kind) as (params, data):
+        with ingest_in_tiledb(tmpdir, spec) as (params, data):
             with pytest.raises(NotImplementedError) as ex:
                 TensorflowTileDBDataset(params)
             assert "TensorKind.SPARSE_CSR tensors not supported" in str(ex.value)

--- a/tiledb/ml/readers/types.py
+++ b/tiledb/ml/readers/types.py
@@ -86,7 +86,7 @@ class ArrayParams:
         else:
             tensor_kind = TensorKind.SPARSE_COO
 
-        factory = TensorSchemaFactories[tensor_kind]
+        factory = TensorSchemaFactories[sparse, tensor_kind]
         tensor_schema = factory(
             kind=tensor_kind,
             _array=self.array,


### PR DESCRIPTION
As mentioned in the #167 description, the `TensorKind` abstraction allows decoupling the TileDB array flavor (dense or sparse) from the generated tensor kind. This PR enables generating dense tensors from sparse TileDB arrays by passing `tensor_kind=TensorKind.DENSE` to the `ArrayParams` of a sparse array.

The actual implementation is contained in a single commit (56599f65aa0e0dda0c430cb9078f73aa83c3f018) that:
- generalizes the `TensorSchemaFactories` mapping to depend on the array flavor (in addition to the tensor kind). 
- adds `SparseToDenseTensorSchema` factory that maps sparse arrays generated by `SparseTensorSchema` to (dense) Numpy arrays.
- makes `MappedTensorSchema` pickleable (required for `num_workers>0`)
