### PR TITLE
Support pytorch 1.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         ml-deps:
-          - "torch==1.12.0+cpu torchvision==0.13.0+cpu torchdata==0.4.0 tensorflow-cpu==2.7.1"
+          - "torch==1.11.0+cpu torchvision==0.12.0+cpu torchdata==0.3.0 tensorflow-cpu==2.7.1"
           - "torch==1.12.1+cpu torchvision==0.13.1+cpu torchdata==0.4.1 tensorflow-cpu==2.8.1"
 
     env:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 tensorflow = ["tensorflow>=2.6"]
-pytorch = ["torch>=1.12", "torchdata"]
+pytorch = ["torch>=1.11", "torchdata"]
 sklearn = ["scikit-learn>=1.0"]
 cloud = ["tiledb-cloud"]
 full = sorted({"torchvision", *tensorflow, *pytorch, *sklearn, *cloud})

--- a/tests/readers/test_pytorch_collators.py
+++ b/tests/readers/test_pytorch_collators.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import scipy.sparse
 import sparse
+import torch
 
 from tiledb.ml.readers import _pytorch_collators as pc
 
@@ -30,6 +31,9 @@ class TestNumpyArrayCollator:
         assert get_tensor_kind(tensor) is pc.TensorKind.DENSE
         np.testing.assert_array_equal(tensor, value)
 
+    @pytest.mark.skipif(
+        not hasattr(torch, "nested"), reason="Nested tensors not supported"
+    )
     def test_collate_nested(self):
         batch = [np.random.rand(8), np.random.rand(3), np.random.rand(7)]
         tensor = pc.NumpyArrayCollator(to_nested=True).collate(batch)

--- a/tiledb/ml/readers/pytorch.py
+++ b/tiledb/ml/readers/pytorch.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Iterator, Sequence, Tuple, Union
 import numpy as np
 import scipy.sparse
 import sparse
+import torchdata
 from torch.utils.data import DataLoader, IterDataPipe
 from torchdata.datapipes.iter import IterableWrapper
 
@@ -65,6 +66,8 @@ def PyTorchTileDBDataLoader(
     datapipe_for_key_range = partial(_get_unbatched_datapipe, schemas)
     num_workers = kwargs.get("num_workers", 0)
     if num_workers:
+        if torchdata.__version__ < "0.4":
+            raise NotImplementedError("torchdata>=0.4 required for multiple workers")
         if any(schema.kind is not TensorKind.DENSE for schema in schemas):
             raise NotImplementedError("https://github.com/pytorch/pytorch/issues/20248")
 


### PR DESCRIPTION
Less aggressive pytorch bump from #178. Add support for pytorch 1.11 with two caveats:
- Nested tensors are not supported. Still `TensoKind.RAGGED` is supported (only) for `batch_size=None` because it generates 1D dense tensors instead of nested.
- Multiprocessing (`num_workers > 0`) is not supported because the [ShardingFilter](https://pytorch.org/data/main/generated/torchdata.datapipes.iter.ShardingFilter.html) of `torchdata` is defective on version 0.3.