### PR TITLE
Update mypy to 0.991 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
     - id: black
   - repo: https://github.com/pycqa/isort
@@ -13,6 +13,6 @@ repos:
     hooks:
     - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.981
+    rev: v0.991
     hooks:
       - id: mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,26 +47,15 @@ per-file-ignores =
     __init__.py: F401, F403
 
 [mypy]
-show_error_codes = True
+# Import discovery
+namespace_packages = False
 ignore_missing_imports = True
-
-# Disallow dynamic typing
-#disallow_any_decorated = True
-#disallow_any_unimported = True
-#disallow_any_expr = True
-#disallow_any_explicit = True
-disallow_any_generics = True
-#disallow_subclassing_any = True
 
 # Untyped definitions and calls
 disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_decorators = True
-
-# None and Optional handling
-no_implicit_optional = True
-strict_optional = True
 
 # Configuring warnings
 warn_redundant_casts = True
@@ -76,7 +65,6 @@ warn_return_any = True
 warn_unreachable = True
 
 # Miscellaneous strictness flags
-implicit_reexport = True
 strict_equality = True
 
 [mypy-tests.*]


### PR DESCRIPTION
- Update mypy to the latest version (0.991) 
- Update the mypy configuration
  - The default value of [namespace_packages](https://mypy.readthedocs.io/en/stable/config_file.html#confval-namespace_packages) has apparently changed from False to True. 
  - For reasons not quite clear yet, this causes a `Source file found twice under different module names` error.
  - Set (for now at least) `namespace_packages` explicitly to False to prevent the above error. 