### PR TITLE
Remove unused SharedObjectLoadingScope in tensorflow_keras

### DIFF
--- a/tiledb/ml/models/tensorflow_keras.py
+++ b/tiledb/ml/models/tensorflow_keras.py
@@ -15,7 +15,6 @@ import tiledb
 
 from ._base import Meta, TileDBArtifact, Timestamp
 
-SharedObjectLoadingScope = keras.utils.generic_utils.SharedObjectLoadingScope
 FunctionalOrSequential = (keras.models.Functional, keras.models.Sequential)
 TFOptimizer = keras.optimizers.TFOptimizer
 get_json_type = keras.saving.saved_model.json_utils.get_json_type


### PR DESCRIPTION
Remove unused SharedObjectLoadingScope in tensorflow_keras. This fixes an import error:

```
File /opt/conda/lib/python3.9/site-packages/tiledb/ml/models/tensorflow_keras.py:18, in <module>
     14 import tiledb
     16 from ._base import Meta, TileDBArtifact, Timestamp
---> 18 SharedObjectLoadingScope = keras.utils.generic_utils.SharedObjectLoadingScope
     19 FunctionalOrSequential = (keras.models.Functional, keras.models.Sequential)
     20 TFOptimizer = keras.optimizers.TFOptimizer

AttributeError: module 'keras.utils.generic_utils' has no attribute 'SharedObjectLoadingScope'
```

[sc-31839]