### PR TITLE
Pin the tensorflow version lower than 2.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Run notebook examples
       run: |
-        pip install pytest-xdist nbmake matplotlib idx2numpy
+        pip install pytest-xdist nbmake matplotlib idx2numpy "numpy<2"
         pytest --disable-warnings --nbmake examples/{models,readers}
         # Run tiledb-cloud in parallel
         if [[ "${{ secrets.TILEDB_API_TOKEN }}" != "" ]]; then

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-tensorflow = ["tensorflow>=2.6"]
+tensorflow = ["tensorflow>=2.6, <2.16.0"]
 pytorch = ["torch>=1.11", "torchdata"]
 sklearn = ["scikit-learn>=1.0"]
 cloud = ["tiledb-cloud"]


### PR DESCRIPTION
This PR:

- Pins the version of TF <2.16 
- Pins the numpy version in notebooks <2.0

Reason:

Tensorflow >=2.16 comes with a default dependency of Keras backend >= 3.0. The latter introduces many changes in its package module, deprecates many modules, changes module paths and generally after some efforts supporting it in an open PR here #214 we were not able to support it with minimal changes in our package. It will require a restructure of our package and a holistic approach which given the current capacity we ll need to revisit it in the near future. 