### PR TITLE
Fix bug in TF dense schema

### DIFF
--- a/tiledb/ml/readers/_tensor_schema/dense.py
+++ b/tiledb/ml/readers/_tensor_schema/dense.py
@@ -66,7 +66,7 @@ class DenseTensorSchema(TensorSchema[np.ndarray]):
 
     @property
     def max_partition_weight(self) -> int:
-        memory_budget = int(self._array._ctx_().config()["sm.mem.total_budget"])
+        memory_budget = int(self._array.ctx.config()["sm.mem.total_budget"])
 
         # The memory budget should be large enough to read the cells of the largest field
         bytes_per_cell = max(dtype.itemsize for dtype in self.field_dtypes)


### PR DESCRIPTION
We have a notebook in the docs to demonstrate dense dataset ingestion for TensorFlow. We got an error when trying to calculate the max_partition_weight property. This PR fixes that bug.

When running this statement:

```py
with (
    tiledb.open(training_images) as x,
    tiledb.open(training_labels) as y,
):
    tiledb_dataset = TensorflowTileDBDataset(
        ArrayParams(array=x),
        ArrayParams(array=y),
    )
...
```

we get the following error:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[14], [line 11](vscode-notebook-cell:?execution_count=14&line=11)
      [5](vscode-notebook-cell:?execution_count=14&line=5) ctx = tiledb.Ctx()
      [7](vscode-notebook-cell:?execution_count=14&line=7) with (
      [8](vscode-notebook-cell:?execution_count=14&line=8)     tiledb.open(training_images) as x,
      [9](vscode-notebook-cell:?execution_count=14&line=9)     tiledb.open(training_labels) as y,
     [10](vscode-notebook-cell:?execution_count=14&line=10) ):
---> [11](vscode-notebook-cell:?execution_count=14&line=11)     tiledb_dataset = TensorflowTileDBDataset(
     [12](vscode-notebook-cell:?execution_count=14&line=12)         ArrayParams(array=x),
     [13](vscode-notebook-cell:?execution_count=14&line=13)         ArrayParams(array=y),
     [14](vscode-notebook-cell:?execution_count=14&line=14)     )
     [15](vscode-notebook-cell:?execution_count=14&line=15)     batched_dataset = tiledb_dataset.batch(128)
     [16](vscode-notebook-cell:?execution_count=14&line=16)     batch_imgs, batch_labels = next(batched_dataset.as_numpy_iterator())

File /opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/tensorflow.py:43, in TensorflowTileDBDataset(num_workers, *all_array_params)
     [40](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/tensorflow.py:40) if not all(key_range.equal_values(schema.key_range) for schema in schemas[1:]):
     [41](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/tensorflow.py:41)     raise ValueError(f"All arrays must have the same key range: {key_range}")
---> [43](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/tensorflow.py:43) max_weights = tuple(schema.max_partition_weight for schema in schemas)
     [44](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/tensorflow.py:44) key_subranges = tuple(key_range.partition_by_count(num_workers or 1))
     [46](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/tensorflow.py:46) def key_range_dataset(key_range_idx: int) -> tf.data.Dataset:

File /opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/tensorflow.py:43, in <genexpr>(.0)
     [40](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/tensorflow.py:40) if not all(key_range.equal_values(schema.key_range) for schema in schemas[1:]):
     [41](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/tensorflow.py:41)     raise ValueError(f"All arrays must have the same key range: {key_range}")
---> [43](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/tensorflow.py:43) max_weights = tuple(schema.max_partition_weight for schema in schemas)
     [44](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/tensorflow.py:44) key_subranges = tuple(key_range.partition_by_count(num_workers or 1))
     [46](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/tensorflow.py:46) def key_range_dataset(key_range_idx: int) -> tf.data.Dataset:

File /opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/_tensor_schema/dense.py:69, in DenseTensorSchema.max_partition_weight(self)
     [67](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/_tensor_schema/dense.py:67) @property
     [68](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/_tensor_schema/dense.py:68) def max_partition_weight(self) -> int:
---> [69](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/_tensor_schema/dense.py:69)     memory_budget = int(self._array._ctx_().config()["sm.mem.total_budget"])
     [71](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/_tensor_schema/dense.py:71)     # The memory budget should be large enough to read the cells of the largest field
     [72](https://file+.vscode-resource.vscode-cdn.net/opt/conda/lib/python3.9/site-packages/tiledb/ml/readers/_tensor_schema/dense.py:72)     bytes_per_cell = max(dtype.itemsize for dtype in self.field_dtypes)

AttributeError: 'DenseArray' object has no attribute '_ctx_'
```